### PR TITLE
Fix handling of --skin-tone

### DIFF
--- a/rofimoji.py
+++ b/rofimoji.py
@@ -1850,7 +1850,6 @@ def parse_arguments() -> argparse.Namespace:
         dest='skin_tone',
         choices=['neutral', 'light', 'medium-light', 'moderate', 'dark brown', 'black', 'ask'],
         default='ask',
-        nargs=1,
         action='store'
     )
     return parser.parse_args()
@@ -1902,7 +1901,7 @@ if __name__ == "__main__":
     if rofi.returncode == 1:
         exit()
     else:
-        emojis = compile_chosen_emojis(stdout.splitlines(), args.skin_tone[0])
+        emojis = compile_chosen_emojis(stdout.splitlines(), args.skin_tone)
 
         if rofi.returncode == 0:
             insert_emojis(emojis, active_window, args.use_clipboard)


### PR DESCRIPTION
When `nargs=1` is given to argparse, it creates a list with one item, which is why the additional `[0]` was needed when reading the value.

However, `default='ask'` means that the default value was `'ask'` rather than `['ask']`, causing the skin tone to be set to `'a'`, resulting in:

```
Traceback (most recent call last):
  File "/usr/bin/rofimoji", line 1905, in <module>
    emojis = compile_chosen_emojis(stdout.splitlines(), args.skin_tone[0])
  File "/usr/bin/rofimoji", line 1870, in compile_chosen_emojis
    emoji = select_skin_tone(emoji, skin_tone)
  File "/usr/bin/rofimoji", line 1756, in select_skin_tone
    return selected_emoji + fitzpatrick_modifiers_reversed[skin_tone]
KeyError: 'a'
```

Instead, don't pass `nargs` to argparse at all - with the default `nargs` value, we just get the value (or default) back, so we don't need the `[0]` anymore.

Fixes #16