### PR TITLE
Focus the window before doing the Shift+Insert

### DIFF
--- a/rofimoji.py
+++ b/rofimoji.py
@@ -4,7 +4,6 @@ import argparse
 import sys
 from subprocess import Popen, PIPE
 from typing import List, Tuple, Union
-from time import sleep
 
 emoji_list = """😀 grinning face <small>(face, grin, grinning face)</small>
 😃 grinning face with big eyes <small>(face, grinning face with big eyes, mouth, open, smile)</small>
@@ -1921,12 +1920,14 @@ def copy_paste_emojis(emojis: str, active_window: str) -> None:
     Popen([
         'xdotool',
         'windowfocus',
+        '--sync',
         active_window,
         'key',
         '--clearmodifiers',
-        'Shift+Insert'
+        'Shift+Insert',
+        'sleep',
+        '0.05',
     ]).wait()
-    sleep(0.05)
     
     Popen(args=['xsel', '-i', '-b'], stdin=PIPE) \
         .communicate(input=old_clipboard_content)

--- a/rofimoji.py
+++ b/rofimoji.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from subprocess import Popen, PIPE
 from typing import List, Tuple, Union
+from time import sleep
 
 emoji_list = """😀 grinning face <small>(face, grin, grinning face)</small>
 😃 grinning face with big eyes <small>(face, grinning face with big eyes, mouth, open, smile)</small>
@@ -1919,13 +1920,14 @@ def copy_paste_emojis(emojis: str, active_window: str) -> None:
 
     Popen([
         'xdotool',
+        'windowfocus',
+        active_window,
         'key',
         '--clearmodifiers',
-        '--window',
-        active_window,
         'Shift+Insert'
     ]).wait()
-
+    sleep(0.05)
+    
     Popen(args=['xsel', '-i', '-b'], stdin=PIPE) \
         .communicate(input=old_clipboard_content)
     Popen(args=['xsel', '-i', '-p'], stdin=PIPE) \


### PR DESCRIPTION
This is the only way I found to make rofimoji work with firefox3: using the clipboard and focusing the window beforehand.

I also have this snippet, that I ended up not using:

    def is_firefox(windowid) -> bool:
        xprop = Popen(args=['xprop', '-id', windowid, 'WM_CLASS'], stdout=PIPE)
        output = xprop.communicate()[0].decode("utf-8")[:-1]
        wmclass = map(lambda x: x.strip(), output.split('=')[1].replace('"', '').split(','))
        return 'firefox' in wmclass