### PR TITLE
Use "/usr/bin/env"

### DIFF
--- a/src/picker/rofimoji.py
+++ b/src/picker/rofimoji.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import argparse
 import os


### PR DESCRIPTION
This is what this line should say. I edited it in GitHub, without testing, but I use this locally. It's just how it should be, because python3 can be supplied through $PATH instead, like on NixOS.