### PR TITLE
Use pathlib and context managers for file operations

### DIFF
--- a/extractors/BlockExtractor.py
+++ b/extractors/BlockExtractor.py
@@ -1,4 +1,5 @@
 import html
+from pathlib import Path
 
 import requests
 
@@ -33,12 +34,9 @@ class BlockExtractor(object):
             if len(block.characters) == 0:
                 continue
 
-            symbol_file = open(f"../picker/data/{block.name.lower().replace(' ', '_')}.csv", 'w')
-
-            for character in block.characters:
-                symbol_file.write(f"{character.char} {html.escape(character.name)}\n")
-
-            symbol_file.close()
+            with Path(f"../picker/data/{block.name.lower().replace(' ', '_')}.csv").open('w') as symbol_file:
+                for character in block.characters:
+                    symbol_file.write(f"{character.char} {html.escape(character.name)}\n")
 
     def extract(self):
         self.fetch_blocks()

--- a/extractors/EmojiExtractor.py
+++ b/extractors/EmojiExtractor.py
@@ -1,5 +1,6 @@
 import html
 from collections import namedtuple
+from pathlib import Path
 from typing import List, Dict
 
 import requests
@@ -91,12 +92,9 @@ class EmojiExtractor(object):
 
     def write_symbol_file(self: 'EmojiExtractor'):
         print('Writing collected emojis to symbol file')
-        symbol_file = open('../picker/data/emojis.csv', 'w')
-
-        for entry in self.compile_entries(self.all_emojis):
-            symbol_file.write(entry + "\n")
-
-        symbol_file.close()
+        with Path('../picker/data/emojis.csv').open('w') as symbol_file:
+            for entry in self.compile_entries(self.all_emojis):
+                symbol_file.write(entry + "\n")
 
     def compile_entries(self: 'EmojiExtractor', emojis: List[Emoji]) -> List[str]:
         annotated_emojis = []
@@ -112,12 +110,10 @@ class EmojiExtractor(object):
 
     def write_metadata_file(self: 'EmojiExtractor'):
         print('Writing metadata to metadata file')
-        metadata_file = open('../picker/copyme.py', 'w')
-
-        metadata_file.write('skin_tone_selectable_emojis={\'')
-        metadata_file.write('\', \''.join(self.base_emojis))
-        metadata_file.write('\'}\n')
-        metadata_file.close()
+        with Path('../picker/copyme.py').open('w') as metadata_file:
+            metadata_file.write('skin_tone_selectable_emojis={\'')
+            metadata_file.write('\', \''.join(self.base_emojis))
+            metadata_file.write('\'}\n')
 
     def extract(self: 'EmojiExtractor'):
         self.write_symbol_file()

--- a/extractors/MathCollectionExtractor.py
+++ b/extractors/MathCollectionExtractor.py
@@ -1,4 +1,5 @@
 import html
+from pathlib import Path
 from typing import List
 
 import requests
@@ -44,12 +45,9 @@ class MathExtractor(object):
             return [int(line, 16)]
 
     def write_file(self: 'MathExtractor', symbols: List[Character]):
-        symbol_file = open(f"../picker/data/math.csv", 'w')
-
-        for character in symbols:
-            symbol_file.write(f"{character.char} {html.escape(character.name)}\n")
-
-        symbol_file.close()
+        with Path(f"../picker/data/math.csv").open('w') as symbol_file:
+            for character in symbols:
+                symbol_file.write(f"{character.char} {html.escape(character.name)}\n")
 
     def extract(self):
         self.write_file(self.fetch_math_symbols())


### PR DESCRIPTION
Replace `os.path`, `fnmatch` modules and `open` method with `pathlib.Path` objects and use context managers when reading/writing files. The `pyxdg` lib provides `pathlib.Path` objects anyway, so we can work with them directly.