### PR TITLE
Allow homedir-relative paths with "~"

### DIFF
--- a/picker/rofimoji.py
+++ b/picker/rofimoji.py
@@ -228,8 +228,8 @@ class Rofimoji:
 
     def load_from_file(self, file_name: str) -> str:
         provided_file = Path(__file__).parent / "data" / f"{file_name}.csv"
-        if Path(file_name).is_file():
-            actual_file_name = Path(file_name)
+        if Path(file_name).expanduser().is_file():
+            actual_file_name = Path(file_name).expanduser()
         elif provided_file.is_file():
             actual_file_name = provided_file
         else:


### PR DESCRIPTION
Paths to custom lists must currently be provided as full paths. Using `pathlib.Path.expanduser()` allows paths to be specified relative to the user's home directory, e.g., `~/.config/rofimoji-custom-list.csv`