### PR TITLE
Don't write recent file if --max-recent 0 was passed

### DIFF
--- a/src/picker/rofimoji.py
+++ b/src/picker/rofimoji.py
@@ -350,6 +350,9 @@ class Rofimoji:
     def save_characters_to_recent_file(self, characters: str) -> None:
         max_recent_from_conf = self.args.max_recent
 
+        if max_recent_from_conf == 0:
+            return
+
         old_file_name = recents_file_location
         new_file_name = old_file_name.with_name('recent_temp')
 


### PR DESCRIPTION
Currently if the command line arguments `--max-recent 0` are passed, the recent history is not displayed but it is still written. It this case, the history file will also grow with unlimited size because the test at this line will never be true: https://github.com/fdw/rofimoji/blob/515ccab8a953d2aeccccf02b582e3d32a6f0e33b/src/picker/rofimoji.py#L367

This simple patch fixes this.