### PR TITLE
🎉 Allow args to be passed to rofi and wofi

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can configure `rofimoji` either with cli arguments or with a config file cal
 | `--skin-tone` | `-s` | `light`, `medium-light`, `moderate`, `dark brown`, `black`, as well as `neutral` and `ask` | Define the skin tone of supporting emojis. `ask` will always ask the user. |
 | `--max-recent` |  | 1-10 | Show at most this many recently picked characters. The number will be capped at 10. |
 | `--prompt` | `-r` | any string | Define the prompt text for `rofimoji`. |
-| `--rofi-args` | | | Define arguments that `rofimoji` will pass through to `rofi`.<br/>Please note that you need to specify it as `--rofi-args="<rofi-args>"` or `--rofi-args " <rofi-args>"` because of a [bug in argparse](https://bugs.python.org/issue9334) |
+| `--selector-args` | | | Define arguments that `rofimoji` will pass through to the selctor (`rofi` or `wofi`).<br/>Please note that you need to specify it as `--selector-args="<selector-args>"` or `--selector-args " <selector-args>"` because of a [bug in argparse](https://bugs.python.org/issue9334) |
 | `--selector` | | `rofi`, `wofi` | Show the selection dialog with this application. |
 | `--clipboarder` | | `xsel`, `xclip`, `wl-copy` | Access the clipboard with this application. |
 | `--typer` | | `xdotool`, `wtype` | Type the characters using this application. |

--- a/src/picker/docs/rofimoji.1
+++ b/src/picker/docs/rofimoji.1
@@ -14,8 +14,8 @@
 {\f[I]neutral\f[R],\f[I]light\f[R],\f[I]medium-light\f[R],\f[I]moderate\f[R],\f[I]dark
 brown\f[R],\f[I]black\f[R],\f[I]ask\f[R]}] [\f[B]\[en]files\f[R]
 {\f[I]all\f[R],\f[I]FILE\f[R] [\f[I]FILE\f[R] \&...]]}
-[\f[B]\[en]prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\[en]rofi-args\f[R]
-\f[I]ROFI_ARGS\f[R]] [\f[B]\[en]max-recent\f[R] \f[I]MAX_RECENT\f[R]]
+[\f[B]\[en]prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\[en]selector-args\f[R]
+\f[I]SELECTOR_ARGS\f[R]] [\f[B]\[en]max-recent\f[R] \f[I]MAX_RECENT\f[R]]
 [\f[B]\[en]clipboarder\f[R] \f[I]CLIPBOARDER\f[R]] [\f[B]\[en]typer\f[R]
 \f[I]TYPER\f[R]] [\f[B]\[en]selector\f[R] \f[I]SELECTOR\f[R]]
 .SH DESCRIPTION
@@ -55,7 +55,7 @@ Read characters from this file instead, one entry per line
 \[en]prompt \f[I]PROMPT\f[R], -r \f[I]PROMPT\f[R]
 Set rofimoj\[cq]s prompt
 .TP
-\[en]rofi-args \f[I]ROFI-ARGS\f[R]
+\[en]selector-args \f[I]SELECTOR-ARGS\f[R]
 A string of arguments to give to the selector.
 .TP
 \[en]max-recent \f[I]MAX-RECENT\f[R]

--- a/src/picker/docs/rofimoji.1.md
+++ b/src/picker/docs/rofimoji.1.md
@@ -12,7 +12,7 @@
 | **rofimoji** \[**-h**] \[**--version**] \[**--action** {*type*,*copy*,*clipboard*,*unicode*,*copy-unicode*,*print*}]
          \[**--skin-tone** {*neutral*,*light*,*medium-light*,*moderate*,*dark brown*,*black*,*ask*}]
          \[**--files** {*all*,*FILE* \[*FILE* ...]]} \[**--prompt** *PROMPT*]
-         \[**--rofi-args** *ROFI_ARGS*] \[**--max-recent** *MAX_RECENT*]
+         \[**--selector-args** *SELECTOR_ARGS*] \[**--max-recent** *MAX_RECENT*]
          \[**--clipboarder** *CLIPBOARDER*] \[**--typer** *TYPER*] \[**--selector** *SELECTOR*]
 
 # DESCRIPTION
@@ -48,9 +48,9 @@ Select, insert, or copy Unicode characters like emoji using rofi.
 
 --prompt _PROMPT_, -r _PROMPT_
 
-:  Set rofimoj's prompt
+:  Set rofimoji's prompt
 
---rofi-args _ROFI-ARGS_
+--selector-args _SELECTOR-ARGS_
 
 :  A string of arguments to give to the selector.
 


### PR DESCRIPTION
Add the `--selector-args` argument as a generic way to send arguments to
rofi or wofi, depending on the user's configuration. The `--rofi-args`
argument still works for backwards compatibility.

Signed-off-by: Major Hayden <major@mhtx.net>