### PR TITLE
use `windowactivate` in xdotool instead of passing `--window` to `type`

### DIFF
--- a/src/picker/typer.py
+++ b/src/picker/typer.py
@@ -54,10 +54,11 @@ class XDoToolTyper(Typer):
     def type_characters(self, characters: str, active_window: str) -> None:
         run([
             'xdotool',
+            'windowactivate',
+            '--sync',
+            active_window,
             'type',
             '--clearmodifiers',
-            '--window',
-            active_window,
             characters
         ])
 


### PR DESCRIPTION
xdotool docs state that `--window` option on `type` may result in window ignoring the events altogether (man page, section "SENDEVENT NOTES"):

"Sending keystrokes to a specific window uses a different API than simply typing to the active window. ... X11 servers will set a special flag on all events generated in this way ... Many programs observe this flag and reject these events."

I seem to have encountered several instances of such situations on different apps, so I propose to call windowactivate before
sending "type" command, and omit the `--window` argument to `type` command. In my testing this change resulted in a much more stable experience.

Also I opted to use `windowactivate` instead of `windowfocus`, because according to the man page it is more reliable and is supposed to work on more window managers.