### PR TITLE
Fix stripping unnecessary whitespace characters

### DIFF
--- a/src/picker/rofimoji.py
+++ b/src/picker/rofimoji.py
@@ -445,7 +445,7 @@ class Rofimoji:
         try:
             with frecency_file_location.open('r') as file:
                 for line in file:
-                    (frecency, character) = line.strip().split(' ')
+                    (frecency, character) = line.strip('\n').split(' ')
                     frecencies[character] = int(frecency)
         except FileNotFoundError:
             pass

--- a/src/picker/rofimoji.py
+++ b/src/picker/rofimoji.py
@@ -227,7 +227,7 @@ class Rofimoji:
             sys.exit()
         else:
             if 10 <= returncode <= 19:
-                characters = self.load_recent_characters(self.args.max_recent)[returncode - 10].strip()
+                characters = self.load_recent_characters(self.args.max_recent)[returncode - 10]
             else:
                 self.choose_action_from_return_code(returncode)
                 characters = self.process_chosen_characters(stdout.splitlines())
@@ -245,7 +245,7 @@ class Rofimoji:
 
     def mode_act_on_selection(self, chosen_character: str, returncode: int) -> None:
         if 10 <= returncode <= 19:
-            characters = self.load_recent_characters(self.args.max_recent)[returncode - 10].strip()
+            characters = self.load_recent_characters(self.args.max_recent)[returncode - 10]
             self.save_characters_to_recent_file(characters)
             self.execute_action(characters)
         else:
@@ -337,11 +337,11 @@ class Rofimoji:
         return resolved_file_names
 
     def load_from_file(self, file: Path) -> List[str]:
-        return file.read_text().strip().split('\n')
+        return file.read_text().strip('\n').split('\n')
 
     def load_recent_characters(self, max: int) -> List[str]:
         try:
-            return recents_file_location.read_text().strip().split('\n')[:max]
+            return [char.strip('\n') for char in recents_file_location.read_text().strip('\n').split('\n')][:max]
         except FileNotFoundError:
             return []
 
@@ -428,7 +428,7 @@ class Rofimoji:
                 with old_file_name.open('r') as old_file:
                     index = 0
                     for line in old_file:
-                        if characters != line.strip():
+                        if characters != line.strip('\n'):
                             if index == max_recent - 1:
                                 break
                             new_file.write(line)


### PR DESCRIPTION
Let's say one would like to insert some whitespace character using rofimoji. For example, a non-breaking space or a medium mathematical space. After choosing the character it gets inserted as expected, but running the program after this operation, results in the following error.
``` python
Traceback (most recent call last):
  File "/usr/bin/rofimoji", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.10/site-packages/picker/rofimoji.py", line 508, in main
    Rofimoji().standalone()
  File "/usr/lib/python3.10/site-packages/picker/rofimoji.py", line 224, in standalone
    returncode, stdout = self.open_main_rofi_window()
  File "/usr/lib/python3.10/site-packages/picker/rofimoji.py", line 356, in open_main_rofi_window
    self.read_character_files(),
  File "/usr/lib/python3.10/site-packages/picker/rofimoji.py", line 296, in read_character_files
    for character in self.read_frecencies().keys():
  File "/usr/lib/python3.10/site-packages/picker/rofimoji.py", line 448, in read_frecencies
    (frecency, character) = line.strip().split(' ')
ValueError: not enough values to unpack (expected 2, got 1)
```
The problem is that entries in the `frecency` file are in the form `<index number> <character>`. When `<character>` is some whitespace character, it gets stripped out, together with a space functioning as the separator, by https://github.com/fdw/rofimoji/blob/be3786752605bd430ec3a3fd17c7ef6d9777f422/src/picker/rofimoji.py#L448
This PR fixes it, but I suspect something similar can happen with other `strip`s. Feel free to edit it.