### PR TITLE
Add Font Awesome 6 extractor

### DIFF
--- a/src/extractors/__main__.py
+++ b/src/extractors/__main__.py
@@ -10,6 +10,7 @@ from .extractor import Extractor
 from .gitmojiextractor import GitmojiExtractor
 from .mathcollectionextractor import MathExtractor
 from .nerdfontextractor import NerdFontExtractor
+from .fontawesome6extractor import FontAwesome6Extractor
 
 if __name__ == "__main__":
     data_directory = pathlib.Path(__file__).parent.parent / 'picker' / 'data'
@@ -22,7 +23,8 @@ if __name__ == "__main__":
         CjkExtractor(),
         MathExtractor(character_factory),
         NerdFontExtractor(),
-        GitmojiExtractor()
+        GitmojiExtractor(),
+        FontAwesome6Extractor()
     ]
 
     for subclass in Extractor.__subclasses__():

--- a/src/extractors/fontawesome6extractor.py
+++ b/src/extractors/fontawesome6extractor.py
@@ -1,0 +1,50 @@
+import html
+from pathlib import Path
+from typing import List
+
+import requests
+
+from .characterfactory import Character
+from .extractor import Extractor
+
+
+class FontAwesome6Extractor(Extractor):
+    __icons: List[Character]
+
+    def __init__(self):
+        self.__icons = []
+
+    def __fetch_icons(self: 'FontAwesome6Extractor'):
+        response = requests.get(
+            'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/metadata/icons.json',
+            timeout=60
+        )
+        for (name, data) in response.json().items():
+            icon = int(data['unicode'], 16)
+            name = f'fa-{name}'
+            char = Character(icon, name)
+            char.aliases: List[str] = []
+            try:
+                for alias in data['aliases']['names']:
+                    char.aliases.append(f'fa-{alias}')
+            except KeyError:
+                pass
+            self.__icons.append(char)
+
+    def __write_to_file(self, target: Path):
+        if len(self.__icons) == 0:
+            return
+
+        with (target / 'fontawesome6.csv').open('w') as symbol_file:
+            for icon in self.__icons:
+                line=f'{icon.directional_char} {html.escape(icon.name.lower())}'
+                if len(icon.aliases) > 0:
+                    line += f" <small>({', '.join(icon.aliases)})</small>\n"
+                else:
+                    line += '\n'
+                symbol_file.write(line)
+
+
+    def extract_to(self, target: Path):
+        self.__fetch_icons()
+        self.__write_to_file(target)

--- a/src/picker/data/fontawesome6.csv
+++ b/src/picker/data/fontawesome6.csv
@@ -1,0 +1,1846 @@
+0 fa-0
+1 fa-1
+2 fa-2
+3 fa-3
+4 fa-4
+5 fa-5
+6 fa-6
+7 fa-7
+8 fa-8
+9 fa-9
+ fa-42-group <small>(fa-innosoft)</small>
+ fa-500px
+A fa-a
+ fa-accessible-icon
+ fa-accusoft
+ fa-address-book <small>(fa-contact-book)</small>
+ fa-address-card <small>(fa-contact-card, fa-vcard)</small>
+ fa-adn
+ fa-adversal
+ fa-affiliatetheme
+ fa-airbnb
+ fa-algolia
+ fa-align-center
+ fa-align-justify
+ fa-align-left
+ fa-align-right
+ fa-alipay
+ fa-amazon
+ fa-amazon-pay
+ fa-amilia
+ fa-anchor
+ fa-anchor-circle-check
+ fa-anchor-circle-exclamation
+ fa-anchor-circle-xmark
+ fa-anchor-lock
+ fa-android
+ fa-angellist
+ fa-angle-down
+ fa-angle-left
+ fa-angle-right
+ fa-angle-up
+ fa-angles-down <small>(fa-angle-double-down)</small>
+ fa-angles-left <small>(fa-angle-double-left)</small>
+ fa-angles-right <small>(fa-angle-double-right)</small>
+ fa-angles-up <small>(fa-angle-double-up)</small>
+ fa-angrycreative
+ fa-angular
+ fa-ankh
+ fa-app-store
+ fa-app-store-ios
+ fa-apper
+ fa-apple
+ fa-apple-pay
+ fa-apple-whole <small>(fa-apple-alt)</small>
+ fa-archway
+ fa-arrow-down
+ fa-arrow-down-1-9 <small>(fa-sort-numeric-asc, fa-sort-numeric-down)</small>
+ fa-arrow-down-9-1 <small>(fa-sort-numeric-desc, fa-sort-numeric-down-alt)</small>
+ fa-arrow-down-a-z <small>(fa-sort-alpha-asc, fa-sort-alpha-down)</small>
+ fa-arrow-down-long <small>(fa-long-arrow-down)</small>
+ fa-arrow-down-short-wide <small>(fa-sort-amount-desc, fa-sort-amount-down-alt)</small>
+ fa-arrow-down-up-across-line
+ fa-arrow-down-up-lock
+ fa-arrow-down-wide-short <small>(fa-sort-amount-asc, fa-sort-amount-down)</small>
+ fa-arrow-down-z-a <small>(fa-sort-alpha-desc, fa-sort-alpha-down-alt)</small>
+ fa-arrow-left
+ fa-arrow-left-long <small>(fa-long-arrow-left)</small>
+ fa-arrow-pointer <small>(fa-mouse-pointer)</small>
+ fa-arrow-right
+ fa-arrow-right-arrow-left <small>(fa-exchange)</small>
+ fa-arrow-right-from-bracket <small>(fa-sign-out)</small>
+ fa-arrow-right-long <small>(fa-long-arrow-right)</small>
+ fa-arrow-right-to-bracket <small>(fa-sign-in)</small>
+ fa-arrow-right-to-city
+ fa-arrow-rotate-left <small>(fa-arrow-left-rotate, fa-arrow-rotate-back, fa-arrow-rotate-backward, fa-undo)</small>
+ fa-arrow-rotate-right <small>(fa-arrow-right-rotate, fa-arrow-rotate-forward, fa-redo)</small>
+ fa-arrow-trend-down
+ fa-arrow-trend-up
+ fa-arrow-turn-down <small>(fa-level-down)</small>
+ fa-arrow-turn-up <small>(fa-level-up)</small>
+ fa-arrow-up
+ fa-arrow-up-1-9 <small>(fa-sort-numeric-up)</small>
+ fa-arrow-up-9-1 <small>(fa-sort-numeric-up-alt)</small>
+ fa-arrow-up-a-z <small>(fa-sort-alpha-up)</small>
+ fa-arrow-up-from-bracket
+ fa-arrow-up-from-ground-water
+ fa-arrow-up-from-water-pump
+ fa-arrow-up-long <small>(fa-long-arrow-up)</small>
+ fa-arrow-up-right-dots
+ fa-arrow-up-right-from-square <small>(fa-external-link)</small>
+ fa-arrow-up-short-wide <small>(fa-sort-amount-up-alt)</small>
+ fa-arrow-up-wide-short <small>(fa-sort-amount-up)</small>
+ fa-arrow-up-z-a <small>(fa-sort-alpha-up-alt)</small>
+ fa-arrows-down-to-line
+ fa-arrows-down-to-people
+ fa-arrows-left-right <small>(fa-arrows-h)</small>
+ fa-arrows-left-right-to-line
+ fa-arrows-rotate <small>(fa-refresh, fa-sync)</small>
+ fa-arrows-spin
+ fa-arrows-split-up-and-left
+ fa-arrows-to-circle
+ fa-arrows-to-dot
+ fa-arrows-to-eye
+ fa-arrows-turn-right
+ fa-arrows-turn-to-dots
+ fa-arrows-up-down <small>(fa-arrows-v)</small>
+ fa-arrows-up-down-left-right <small>(fa-arrows)</small>
+ fa-arrows-up-to-line
+ fa-artstation
+* fa-asterisk
+ fa-asymmetrik
+@ fa-at
+ fa-atlassian
+ fa-atom
+ fa-audible
+ fa-audio-description
+ fa-austral-sign
+ fa-autoprefixer
+ fa-avianex
+ fa-aviato
+ fa-award
+ fa-aws
+B fa-b
+ fa-baby
+ fa-baby-carriage <small>(fa-carriage-baby)</small>
+ fa-backward
+ fa-backward-fast <small>(fa-fast-backward)</small>
+ fa-backward-step <small>(fa-step-backward)</small>
+ fa-bacon
+ fa-bacteria
+ fa-bacterium
+ fa-bag-shopping <small>(fa-shopping-bag)</small>
+ fa-bahai
+ fa-baht-sign
+ fa-ban <small>(fa-cancel)</small>
+ fa-ban-smoking <small>(fa-smoking-ban)</small>
+ fa-bandage <small>(fa-band-aid)</small>
+ fa-bandcamp
+ fa-barcode
+ fa-bars <small>(fa-navicon)</small>
+ fa-bars-progress <small>(fa-tasks-alt)</small>
+ fa-bars-staggered <small>(fa-reorder, fa-stream)</small>
+ fa-baseball <small>(fa-baseball-ball)</small>
+ fa-baseball-bat-ball
+ fa-basket-shopping <small>(fa-shopping-basket)</small>
+ fa-basketball <small>(fa-basketball-ball)</small>
+ fa-bath <small>(fa-bathtub)</small>
+ fa-battery-empty <small>(fa-battery-0)</small>
+ fa-battery-full <small>(fa-battery, fa-battery-5)</small>
+ fa-battery-half <small>(fa-battery-3)</small>
+ fa-battery-quarter <small>(fa-battery-2)</small>
+ fa-battery-three-quarters <small>(fa-battery-4)</small>
+ fa-battle-net
+ fa-bed
+ fa-bed-pulse <small>(fa-procedures)</small>
+ fa-beer-mug-empty <small>(fa-beer)</small>
+ fa-behance
+ fa-behance-square
+ fa-bell
+ fa-bell-concierge <small>(fa-concierge-bell)</small>
+ fa-bell-slash
+ fa-bezier-curve
+ fa-bicycle
+ fa-bilibili
+ fa-bimobject
+ fa-binoculars
+ fa-biohazard
+ fa-bitbucket
+ fa-bitcoin
+ fa-bitcoin-sign
+ fa-bity
+ fa-black-tie
+ fa-blackberry
+ fa-blender
+ fa-blender-phone
+ fa-blog
+ fa-blogger
+ fa-blogger-b
+ fa-bluetooth
+ fa-bluetooth-b
+ fa-bold
+ fa-bolt <small>(fa-zap)</small>
+ fa-bolt-lightning
+ fa-bomb
+ fa-bone
+ fa-bong
+ fa-book
+ fa-book-atlas <small>(fa-atlas)</small>
+ fa-book-bible <small>(fa-bible)</small>
+ fa-book-bookmark
+ fa-book-journal-whills <small>(fa-journal-whills)</small>
+ fa-book-medical
+ fa-book-open
+ fa-book-open-reader <small>(fa-book-reader)</small>
+ fa-book-quran <small>(fa-quran)</small>
+ fa-book-skull <small>(fa-book-dead)</small>
+ fa-bookmark
+ fa-bootstrap
+ fa-border-all
+ fa-border-none
+ fa-border-top-left <small>(fa-border-style)</small>
+ fa-bore-hole
+ fa-bots
+ fa-bottle-droplet
+ fa-bottle-water
+ fa-bowl-food
+ fa-bowl-rice
+ fa-bowling-ball
+ fa-box
+ fa-box-archive <small>(fa-archive)</small>
+ fa-box-open
+ fa-box-tissue
+ fa-boxes-packing
+ fa-boxes-stacked <small>(fa-boxes, fa-boxes-alt)</small>
+ fa-braille
+ fa-brain
+ fa-brazilian-real-sign
+ fa-bread-slice
+ fa-bridge
+ fa-bridge-circle-check
+ fa-bridge-circle-exclamation
+ fa-bridge-circle-xmark
+ fa-bridge-lock
+ fa-bridge-water
+ fa-briefcase
+ fa-briefcase-medical
+ fa-broom
+ fa-broom-ball <small>(fa-quidditch, fa-quidditch-broom-ball)</small>
+ fa-brush
+ fa-btc
+ fa-bucket
+ fa-buffer
+ fa-bug
+ fa-bug-slash
+ fa-bugs
+ fa-building
+ fa-building-circle-arrow-right
+ fa-building-circle-check
+ fa-building-circle-exclamation
+ fa-building-circle-xmark
+ fa-building-columns <small>(fa-bank, fa-institution, fa-museum, fa-university)</small>
+ fa-building-flag
+ fa-building-lock
+ fa-building-ngo
+ fa-building-shield
+ fa-building-un
+ fa-building-user
+ fa-building-wheat
+ fa-bullhorn
+ fa-bullseye
+ fa-burger <small>(fa-hamburger)</small>
+ fa-buromobelexperte
+ fa-burst
+ fa-bus
+ fa-bus-simple <small>(fa-bus-alt)</small>
+ fa-business-time <small>(fa-briefcase-clock)</small>
+ fa-buy-n-large
+ fa-buysellads
+C fa-c
+ fa-cake-candles <small>(fa-birthday-cake, fa-cake)</small>
+ fa-calculator
+ fa-calendar
+ fa-calendar-check
+ fa-calendar-day
+ fa-calendar-days <small>(fa-calendar-alt)</small>
+ fa-calendar-minus
+ fa-calendar-plus
+ fa-calendar-week
+ fa-calendar-xmark <small>(fa-calendar-times)</small>
+ fa-camera <small>(fa-camera-alt)</small>
+ fa-camera-retro
+ fa-camera-rotate
+ fa-campground
+ fa-canadian-maple-leaf
+ fa-candy-cane
+ fa-cannabis
+ fa-capsules
+ fa-car <small>(fa-automobile)</small>
+ fa-car-battery <small>(fa-battery-car)</small>
+ fa-car-burst <small>(fa-car-crash)</small>
+ fa-car-on
+ fa-car-rear <small>(fa-car-alt)</small>
+ fa-car-side
+ fa-car-tunnel
+ fa-caravan
+ fa-caret-down
+ fa-caret-left
+ fa-caret-right
+ fa-caret-up
+ fa-carrot
+ fa-cart-arrow-down
+ fa-cart-flatbed <small>(fa-dolly-flatbed)</small>
+ fa-cart-flatbed-suitcase <small>(fa-luggage-cart)</small>
+ fa-cart-plus
+ fa-cart-shopping <small>(fa-shopping-cart)</small>
+ fa-cash-register
+ fa-cat
+ fa-cc-amazon-pay
+ fa-cc-amex
+ fa-cc-apple-pay
+ fa-cc-diners-club
+ fa-cc-discover
+ fa-cc-jcb
+ fa-cc-mastercard
+ fa-cc-paypal
+ fa-cc-stripe
+ fa-cc-visa
+ fa-cedi-sign
+ fa-cent-sign
+ fa-centercode
+ fa-centos
+ fa-certificate
+ fa-chair
+ fa-chalkboard <small>(fa-blackboard)</small>
+ fa-chalkboard-user <small>(fa-chalkboard-teacher)</small>
+ fa-champagne-glasses <small>(fa-glass-cheers)</small>
+ fa-charging-station
+ fa-chart-area <small>(fa-area-chart)</small>
+ fa-chart-bar <small>(fa-bar-chart)</small>
+ fa-chart-column
+ fa-chart-gantt
+ fa-chart-line <small>(fa-line-chart)</small>
+ fa-chart-pie <small>(fa-pie-chart)</small>
+ fa-chart-simple
+ fa-check
+ fa-check-double
+ fa-check-to-slot <small>(fa-vote-yea)</small>
+ fa-cheese
+ fa-chess
+ fa-chess-bishop
+ fa-chess-board
+ fa-chess-king
+ fa-chess-knight
+ fa-chess-pawn
+ fa-chess-queen
+ fa-chess-rook
+ fa-chevron-down
+ fa-chevron-left
+ fa-chevron-right
+ fa-chevron-up
+ fa-child
+ fa-child-dress
+ fa-child-reaching
+ fa-child-rifle
+ fa-children
+ fa-chrome
+ fa-chromecast
+ fa-church
+ fa-circle
+ fa-circle-arrow-down <small>(fa-arrow-circle-down)</small>
+ fa-circle-arrow-left <small>(fa-arrow-circle-left)</small>
+ fa-circle-arrow-right <small>(fa-arrow-circle-right)</small>
+ fa-circle-arrow-up <small>(fa-arrow-circle-up)</small>
+ fa-circle-check <small>(fa-check-circle)</small>
+ fa-circle-chevron-down <small>(fa-chevron-circle-down)</small>
+ fa-circle-chevron-left <small>(fa-chevron-circle-left)</small>
+ fa-circle-chevron-right <small>(fa-chevron-circle-right)</small>
+ fa-circle-chevron-up <small>(fa-chevron-circle-up)</small>
+ fa-circle-dollar-to-slot <small>(fa-donate)</small>
+ fa-circle-dot <small>(fa-dot-circle)</small>
+ fa-circle-down <small>(fa-arrow-alt-circle-down)</small>
+ fa-circle-exclamation <small>(fa-exclamation-circle)</small>
+ fa-circle-h <small>(fa-hospital-symbol)</small>
+ fa-circle-half-stroke <small>(fa-adjust)</small>
+ fa-circle-info <small>(fa-info-circle)</small>
+ fa-circle-left <small>(fa-arrow-alt-circle-left)</small>
+ fa-circle-minus <small>(fa-minus-circle)</small>
+ fa-circle-nodes
+ fa-circle-notch
+ fa-circle-pause <small>(fa-pause-circle)</small>
+ fa-circle-play <small>(fa-play-circle)</small>
+ fa-circle-plus <small>(fa-plus-circle)</small>
+ fa-circle-question <small>(fa-question-circle)</small>
+ fa-circle-radiation <small>(fa-radiation-alt)</small>
+ fa-circle-right <small>(fa-arrow-alt-circle-right)</small>
+ fa-circle-stop <small>(fa-stop-circle)</small>
+ fa-circle-up <small>(fa-arrow-alt-circle-up)</small>
+ fa-circle-user <small>(fa-user-circle)</small>
+ fa-circle-xmark <small>(fa-times-circle, fa-xmark-circle)</small>
+ fa-city
+ fa-clapperboard
+ fa-clipboard
+ fa-clipboard-check
+ fa-clipboard-list
+ fa-clipboard-question
+ fa-clipboard-user
+ fa-clock <small>(fa-clock-four)</small>
+ fa-clock-rotate-left <small>(fa-history)</small>
+ fa-clone
+ fa-closed-captioning
+ fa-cloud
+ fa-cloud-arrow-down <small>(fa-cloud-download, fa-cloud-download-alt)</small>
+ fa-cloud-arrow-up <small>(fa-cloud-upload, fa-cloud-upload-alt)</small>
+ fa-cloud-bolt <small>(fa-thunderstorm)</small>
+ fa-cloud-meatball
+ fa-cloud-moon
+ fa-cloud-moon-rain
+ fa-cloud-rain
+ fa-cloud-showers-heavy
+ fa-cloud-showers-water
+ fa-cloud-sun
+ fa-cloud-sun-rain
+ fa-cloudflare
+ fa-cloudscale
+ fa-cloudsmith
+ fa-cloudversify
+ fa-clover
+ fa-cmplid
+ fa-code
+ fa-code-branch
+ fa-code-commit
+ fa-code-compare
+ fa-code-fork
+ fa-code-merge
+ fa-code-pull-request
+ fa-codepen
+ fa-codiepie
+ fa-coins
+ fa-colon-sign
+ fa-comment
+ fa-comment-dollar
+ fa-comment-dots <small>(fa-commenting)</small>
+ fa-comment-medical
+ fa-comment-slash
+ fa-comment-sms <small>(fa-sms)</small>
+ fa-comments
+ fa-comments-dollar
+ fa-compact-disc
+ fa-compass
+ fa-compass-drafting <small>(fa-drafting-compass)</small>
+ fa-compress
+ fa-computer
+ fa-computer-mouse <small>(fa-mouse)</small>
+ fa-confluence
+ fa-connectdevelop
+ fa-contao
+ fa-cookie
+ fa-cookie-bite
+ fa-copy
+ fa-copyright
+ fa-cotton-bureau
+ fa-couch
+ fa-cow
+ fa-cpanel
+ fa-creative-commons
+ fa-creative-commons-by
+ fa-creative-commons-nc
+ fa-creative-commons-nc-eu
+ fa-creative-commons-nc-jp
+ fa-creative-commons-nd
+ fa-creative-commons-pd
+ fa-creative-commons-pd-alt
+ fa-creative-commons-remix
+ fa-creative-commons-sa
+ fa-creative-commons-sampling
+ fa-creative-commons-sampling-plus
+ fa-creative-commons-share
+ fa-creative-commons-zero
+ fa-credit-card <small>(fa-credit-card-alt)</small>
+ fa-critical-role
+ fa-crop
+ fa-crop-simple <small>(fa-crop-alt)</small>
+ fa-cross
+ fa-crosshairs
+ fa-crow
+ fa-crown
+ fa-crutch
+ fa-cruzeiro-sign
+ fa-css3
+ fa-css3-alt
+ fa-cube
+ fa-cubes
+ fa-cubes-stacked
+ fa-cuttlefish
+D fa-d
+ fa-d-and-d
+ fa-d-and-d-beyond
+ fa-dailymotion
+ fa-dashcube
+ fa-database
+ fa-deezer
+ fa-delete-left <small>(fa-backspace)</small>
+ fa-delicious
+ fa-democrat
+ fa-deploydog
+ fa-deskpro
+ fa-desktop <small>(fa-desktop-alt)</small>
+ fa-dev
+ fa-deviantart
+ fa-dharmachakra
+ fa-dhl
+ fa-diagram-next
+ fa-diagram-predecessor
+ fa-diagram-project <small>(fa-project-diagram)</small>
+ fa-diagram-successor
+ fa-diamond
+ fa-diamond-turn-right <small>(fa-directions)</small>
+ fa-diaspora
+ fa-dice
+ fa-dice-d20
+ fa-dice-d6
+ fa-dice-five
+ fa-dice-four
+ fa-dice-one
+ fa-dice-six
+ fa-dice-three
+ fa-dice-two
+ fa-digg
+ fa-digital-ocean
+ fa-discord
+ fa-discourse
+ fa-disease
+ fa-display
+ fa-divide
+ fa-dna
+ fa-dochub
+ fa-docker
+ fa-dog
+$ fa-dollar-sign <small>(fa-dollar, fa-usd)</small>
+ fa-dolly <small>(fa-dolly-box)</small>
+ fa-dong-sign
+ fa-door-closed
+ fa-door-open
+ fa-dove
+ fa-down-left-and-up-right-to-center <small>(fa-compress-alt)</small>
+ fa-down-long <small>(fa-long-arrow-alt-down)</small>
+ fa-download
+ fa-draft2digital
+ fa-dragon
+ fa-draw-polygon
+ fa-dribbble
+ fa-dribbble-square
+ fa-dropbox
+ fa-droplet <small>(fa-tint)</small>
+ fa-droplet-slash <small>(fa-tint-slash)</small>
+ fa-drum
+ fa-drum-steelpan
+ fa-drumstick-bite
+ fa-drupal
+ fa-dumbbell
+ fa-dumpster
+ fa-dumpster-fire
+ fa-dungeon
+ fa-dyalog
+E fa-e
+ fa-ear-deaf <small>(fa-deaf, fa-deafness, fa-hard-of-hearing)</small>
+ fa-ear-listen <small>(fa-assistive-listening-systems)</small>
+ fa-earlybirds
+ fa-earth-africa <small>(fa-globe-africa)</small>
+ fa-earth-americas <small>(fa-earth, fa-earth-america, fa-globe-americas)</small>
+ fa-earth-asia <small>(fa-globe-asia)</small>
+ fa-earth-europe <small>(fa-globe-europe)</small>
+ fa-earth-oceania <small>(fa-globe-oceania)</small>
+ fa-ebay
+ fa-edge
+ fa-edge-legacy
+ fa-egg
+ fa-eject
+ fa-elementor
+ fa-elevator
+ fa-ellipsis <small>(fa-ellipsis-h)</small>
+ fa-ellipsis-vertical <small>(fa-ellipsis-v)</small>
+ fa-ello
+ fa-ember
+ fa-empire
+ fa-envelope
+ fa-envelope-circle-check
+ fa-envelope-open
+ fa-envelope-open-text
+ fa-envelopes-bulk <small>(fa-mail-bulk)</small>
+ fa-envira
+= fa-equals
+ fa-eraser
+ fa-erlang
+ fa-ethereum
+ fa-ethernet
+ fa-etsy
+ fa-euro-sign <small>(fa-eur, fa-euro)</small>
+ fa-evernote
+! fa-exclamation
+ fa-expand
+ fa-expeditedssl
+ fa-explosion
+ fa-eye
+ fa-eye-dropper <small>(fa-eye-dropper-empty, fa-eyedropper)</small>
+ fa-eye-low-vision <small>(fa-low-vision)</small>
+ fa-eye-slash
+F fa-f
+ fa-face-angry <small>(fa-angry)</small>
+ fa-face-dizzy <small>(fa-dizzy)</small>
+ fa-face-flushed <small>(fa-flushed)</small>
+ fa-face-frown <small>(fa-frown)</small>
+ fa-face-frown-open <small>(fa-frown-open)</small>
+ fa-face-grimace <small>(fa-grimace)</small>
+ fa-face-grin <small>(fa-grin)</small>
+ fa-face-grin-beam <small>(fa-grin-beam)</small>
+ fa-face-grin-beam-sweat <small>(fa-grin-beam-sweat)</small>
+ fa-face-grin-hearts <small>(fa-grin-hearts)</small>
+ fa-face-grin-squint <small>(fa-grin-squint)</small>
+ fa-face-grin-squint-tears <small>(fa-grin-squint-tears)</small>
+ fa-face-grin-stars <small>(fa-grin-stars)</small>
+ fa-face-grin-tears <small>(fa-grin-tears)</small>
+ fa-face-grin-tongue <small>(fa-grin-tongue)</small>
+ fa-face-grin-tongue-squint <small>(fa-grin-tongue-squint)</small>
+ fa-face-grin-tongue-wink <small>(fa-grin-tongue-wink)</small>
+ fa-face-grin-wide <small>(fa-grin-alt)</small>
+ fa-face-grin-wink <small>(fa-grin-wink)</small>
+ fa-face-kiss <small>(fa-kiss)</small>
+ fa-face-kiss-beam <small>(fa-kiss-beam)</small>
+ fa-face-kiss-wink-heart <small>(fa-kiss-wink-heart)</small>
+ fa-face-laugh <small>(fa-laugh)</small>
+ fa-face-laugh-beam <small>(fa-laugh-beam)</small>
+ fa-face-laugh-squint <small>(fa-laugh-squint)</small>
+ fa-face-laugh-wink <small>(fa-laugh-wink)</small>
+ fa-face-meh <small>(fa-meh)</small>
+ fa-face-meh-blank <small>(fa-meh-blank)</small>
+ fa-face-rolling-eyes <small>(fa-meh-rolling-eyes)</small>
+ fa-face-sad-cry <small>(fa-sad-cry)</small>
+ fa-face-sad-tear <small>(fa-sad-tear)</small>
+ fa-face-smile <small>(fa-smile)</small>
+ fa-face-smile-beam <small>(fa-smile-beam)</small>
+ fa-face-smile-wink <small>(fa-smile-wink)</small>
+ fa-face-surprise <small>(fa-surprise)</small>
+ fa-face-tired <small>(fa-tired)</small>
+ fa-facebook
+ fa-facebook-f
+ fa-facebook-messenger
+ fa-facebook-square
+ fa-fan
+ fa-fantasy-flight-games
+ fa-faucet
+ fa-faucet-drip
+ fa-fax
+ fa-feather
+ fa-feather-pointed <small>(fa-feather-alt)</small>
+ fa-fedex
+ fa-fedora
+ fa-ferry
+ fa-figma
+ fa-file
+ fa-file-arrow-down <small>(fa-file-download)</small>
+ fa-file-arrow-up <small>(fa-file-upload)</small>
+ fa-file-audio
+ fa-file-circle-check
+ fa-file-circle-exclamation
+ fa-file-circle-minus
+ fa-file-circle-plus
+ fa-file-circle-question
+ fa-file-circle-xmark
+ fa-file-code
+ fa-file-contract
+ fa-file-csv
+ fa-file-excel
+ fa-file-export <small>(fa-arrow-right-from-file)</small>
+ fa-file-image
+ fa-file-import <small>(fa-arrow-right-to-file)</small>
+ fa-file-invoice
+ fa-file-invoice-dollar
+ fa-file-lines <small>(fa-file-alt, fa-file-text)</small>
+ fa-file-medical
+ fa-file-pdf
+ fa-file-pen <small>(fa-file-edit)</small>
+ fa-file-powerpoint
+ fa-file-prescription
+ fa-file-shield
+ fa-file-signature
+ fa-file-video
+ fa-file-waveform <small>(fa-file-medical-alt)</small>
+ fa-file-word
+ fa-file-zipper <small>(fa-file-archive)</small>
+ fa-fill
+ fa-fill-drip
+ fa-film
+ fa-filter
+ fa-filter-circle-dollar <small>(fa-funnel-dollar)</small>
+ fa-filter-circle-xmark
+ fa-fingerprint
+ fa-fire
+ fa-fire-burner
+ fa-fire-extinguisher
+ fa-fire-flame-curved <small>(fa-fire-alt)</small>
+ fa-fire-flame-simple <small>(fa-burn)</small>
+ fa-firefox
+ fa-firefox-browser
+ fa-first-order
+ fa-first-order-alt
+ fa-firstdraft
+ fa-fish
+ fa-fish-fins
+ fa-flag
+ fa-flag-checkered
+ fa-flag-usa
+ fa-flask
+ fa-flask-vial
+ fa-flickr
+ fa-flipboard
+ fa-floppy-disk <small>(fa-save)</small>
+ fa-florin-sign
+ fa-fly
+ fa-folder <small>(fa-folder-blank)</small>
+ fa-folder-closed
+ fa-folder-minus
+ fa-folder-open
+ fa-folder-plus
+ fa-folder-tree
+ fa-font
+ fa-font-awesome <small>(fa-font-awesome-flag, fa-font-awesome-logo-full)</small>
+ fa-fonticons
+ fa-fonticons-fi
+ fa-football <small>(fa-football-ball)</small>
+ fa-fort-awesome
+ fa-fort-awesome-alt
+ fa-forumbee
+ fa-forward
+ fa-forward-fast <small>(fa-fast-forward)</small>
+ fa-forward-step <small>(fa-step-forward)</small>
+ fa-foursquare
+ fa-franc-sign
+ fa-free-code-camp
+ fa-freebsd
+ fa-frog
+ fa-fulcrum
+ fa-futbol <small>(fa-futbol-ball, fa-soccer-ball)</small>
+G fa-g
+ fa-galactic-republic
+ fa-galactic-senate
+ fa-gamepad
+ fa-gas-pump
+ fa-gauge <small>(fa-dashboard, fa-gauge-med, fa-tachometer-alt-average)</small>
+ fa-gauge-high <small>(fa-tachometer-alt, fa-tachometer-alt-fast)</small>
+ fa-gauge-simple <small>(fa-gauge-simple-med, fa-tachometer-average)</small>
+ fa-gauge-simple-high <small>(fa-tachometer, fa-tachometer-fast)</small>
+ fa-gavel <small>(fa-legal)</small>
+ fa-gear <small>(fa-cog)</small>
+ fa-gears <small>(fa-cogs)</small>
+ fa-gem
+ fa-genderless
+ fa-get-pocket
+ fa-gg
+ fa-gg-circle
+ fa-ghost
+ fa-gift
+ fa-gifts
+ fa-git
+ fa-git-alt
+ fa-git-square
+ fa-github
+ fa-github-alt
+ fa-github-square
+ fa-gitkraken
+ fa-gitlab
+ fa-gitter
+ fa-glass-water
+ fa-glass-water-droplet
+ fa-glasses
+ fa-glide
+ fa-glide-g
+ fa-globe
+ fa-gofore
+ fa-golang
+ fa-golf-ball-tee <small>(fa-golf-ball)</small>
+ fa-goodreads
+ fa-goodreads-g
+ fa-google
+ fa-google-drive
+ fa-google-pay
+ fa-google-play
+ fa-google-plus
+ fa-google-plus-g
+ fa-google-plus-square
+ fa-google-wallet
+ fa-gopuram
+ fa-graduation-cap <small>(fa-mortar-board)</small>
+ fa-gratipay
+ fa-grav
+> fa-greater-than
+ fa-greater-than-equal
+ fa-grip <small>(fa-grip-horizontal)</small>
+ fa-grip-lines
+ fa-grip-lines-vertical
+ fa-grip-vertical
+ fa-gripfire
+ fa-group-arrows-rotate
+ fa-grunt
+ fa-guarani-sign
+ fa-guilded
+ fa-guitar
+ fa-gulp
+ fa-gun
+H fa-h
+ fa-hacker-news
+ fa-hacker-news-square
+ fa-hackerrank
+ fa-hammer
+ fa-hamsa
+ fa-hand <small>(fa-hand-paper)</small>
+ fa-hand-back-fist <small>(fa-hand-rock)</small>
+ fa-hand-dots <small>(fa-allergies)</small>
+ fa-hand-fist <small>(fa-fist-raised)</small>
+ fa-hand-holding
+ fa-hand-holding-dollar <small>(fa-hand-holding-usd)</small>
+ fa-hand-holding-droplet <small>(fa-hand-holding-water)</small>
+ fa-hand-holding-hand
+ fa-hand-holding-heart
+ fa-hand-holding-medical
+ fa-hand-lizard
+ fa-hand-middle-finger
+ fa-hand-peace
+ fa-hand-point-down
+ fa-hand-point-left
+ fa-hand-point-right
+ fa-hand-point-up
+ fa-hand-pointer
+ fa-hand-scissors
+ fa-hand-sparkles
+ fa-hand-spock
+ fa-handcuffs
+ fa-hands <small>(fa-sign-language, fa-signing)</small>
+ fa-hands-asl-interpreting <small>(fa-american-sign-language-interpreting, fa-asl-interpreting, fa-hands-american-sign-language-interpreting)</small>
+ fa-hands-bound
+ fa-hands-bubbles <small>(fa-hands-wash)</small>
+ fa-hands-clapping
+ fa-hands-holding
+ fa-hands-holding-child
+ fa-hands-holding-circle
+ fa-hands-praying <small>(fa-praying-hands)</small>
+ fa-handshake
+ fa-handshake-angle <small>(fa-hands-helping)</small>
+ fa-handshake-simple <small>(fa-handshake-alt)</small>
+ fa-handshake-simple-slash <small>(fa-handshake-alt-slash)</small>
+ fa-handshake-slash
+ fa-hanukiah
+ fa-hard-drive <small>(fa-hdd)</small>
+ fa-hashnode
+# fa-hashtag
+ fa-hat-cowboy
+ fa-hat-cowboy-side
+ fa-hat-wizard
+ fa-head-side-cough
+ fa-head-side-cough-slash
+ fa-head-side-mask
+ fa-head-side-virus
+ fa-heading <small>(fa-header)</small>
+ fa-headphones
+ fa-headphones-simple <small>(fa-headphones-alt)</small>
+ fa-headset
+ fa-heart
+ fa-heart-circle-bolt
+ fa-heart-circle-check
+ fa-heart-circle-exclamation
+ fa-heart-circle-minus
+ fa-heart-circle-plus
+ fa-heart-circle-xmark
+ fa-heart-crack <small>(fa-heart-broken)</small>
+ fa-heart-pulse <small>(fa-heartbeat)</small>
+ fa-helicopter
+ fa-helicopter-symbol
+ fa-helmet-safety <small>(fa-hard-hat, fa-hat-hard)</small>
+ fa-helmet-un
+ fa-highlighter
+ fa-hill-avalanche
+ fa-hill-rockslide
+ fa-hippo
+ fa-hips
+ fa-hire-a-helper
+ fa-hive
+ fa-hockey-puck
+ fa-holly-berry
+ fa-hooli
+ fa-hornbill
+ fa-horse
+ fa-horse-head
+ fa-hospital <small>(fa-hospital-alt, fa-hospital-wide)</small>
+ fa-hospital-user
+ fa-hot-tub-person <small>(fa-hot-tub)</small>
+ fa-hotdog
+ fa-hotel
+ fa-hotjar
+ fa-hourglass <small>(fa-hourglass-2, fa-hourglass-half)</small>
+ fa-hourglass-empty
+ fa-hourglass-end <small>(fa-hourglass-3)</small>
+ fa-hourglass-start <small>(fa-hourglass-1)</small>
+ fa-house <small>(fa-home, fa-home-alt, fa-home-lg-alt)</small>
+ fa-house-chimney <small>(fa-home-lg)</small>
+ fa-house-chimney-crack <small>(fa-house-damage)</small>
+ fa-house-chimney-medical <small>(fa-clinic-medical)</small>
+ fa-house-chimney-user
+ fa-house-chimney-window
+ fa-house-circle-check
+ fa-house-circle-exclamation
+ fa-house-circle-xmark
+ fa-house-crack
+ fa-house-fire
+ fa-house-flag
+ fa-house-flood-water
+ fa-house-flood-water-circle-arrow-right
+ fa-house-laptop <small>(fa-laptop-house)</small>
+ fa-house-lock
+ fa-house-medical
+ fa-house-medical-circle-check
+ fa-house-medical-circle-exclamation
+ fa-house-medical-circle-xmark
+ fa-house-medical-flag
+ fa-house-signal
+ fa-house-tsunami
+ fa-house-user <small>(fa-home-user)</small>
+ fa-houzz
+ fa-hryvnia-sign <small>(fa-hryvnia)</small>
+ fa-html5
+ fa-hubspot
+ fa-hurricane
+I fa-i
+ fa-i-cursor
+ fa-ice-cream
+ fa-icicles
+ fa-icons <small>(fa-heart-music-camera-bolt)</small>
+ fa-id-badge
+ fa-id-card <small>(fa-drivers-license)</small>
+ fa-id-card-clip <small>(fa-id-card-alt)</small>
+ fa-ideal
+ fa-igloo
+ fa-image
+ fa-image-portrait <small>(fa-portrait)</small>
+ fa-images
+ fa-imdb
+ fa-inbox
+ fa-indent
+ fa-indian-rupee-sign <small>(fa-indian-rupee, fa-inr)</small>
+ fa-industry
+ fa-infinity
+ fa-info
+ fa-instagram
+ fa-instagram-square
+ fa-instalod
+ fa-intercom
+ fa-internet-explorer
+ fa-invision
+ fa-ioxhost
+ fa-italic
+ fa-itch-io
+ fa-itunes
+ fa-itunes-note
+J fa-j
+ fa-jar
+ fa-jar-wheat
+ fa-java
+ fa-jedi
+ fa-jedi-order
+ fa-jenkins
+ fa-jet-fighter <small>(fa-fighter-jet)</small>
+ fa-jet-fighter-up
+ fa-jira
+ fa-joget
+ fa-joint
+ fa-joomla
+ fa-js
+ fa-js-square
+ fa-jsfiddle
+ fa-jug-detergent
+K fa-k
+ fa-kaaba
+ fa-kaggle
+ fa-key
+ fa-keybase
+ fa-keyboard
+ fa-keycdn
+ fa-khanda
+ fa-kickstarter
+ fa-kickstarter-k
+ fa-kip-sign
+ fa-kit-medical <small>(fa-first-aid)</small>
+ fa-kitchen-set
+ fa-kiwi-bird
+ fa-korvue
+L fa-l
+ fa-land-mine-on
+ fa-landmark
+ fa-landmark-dome <small>(fa-landmark-alt)</small>
+ fa-landmark-flag
+ fa-language
+ fa-laptop
+ fa-laptop-code
+ fa-laptop-file
+ fa-laptop-medical
+ fa-laravel
+ fa-lari-sign
+ fa-lastfm
+ fa-lastfm-square
+ fa-layer-group
+ fa-leaf
+ fa-leanpub
+ fa-left-long <small>(fa-long-arrow-alt-left)</small>
+ fa-left-right <small>(fa-arrows-alt-h)</small>
+ fa-lemon
+ fa-less
+< fa-less-than
+ fa-less-than-equal
+ fa-life-ring
+ fa-lightbulb
+ fa-line
+ fa-lines-leaning
+ fa-link <small>(fa-chain)</small>
+ fa-link-slash <small>(fa-chain-broken, fa-chain-slash, fa-unlink)</small>
+ fa-linkedin
+ fa-linkedin-in
+ fa-linode
+ fa-linux
+ fa-lira-sign
+ fa-list <small>(fa-list-squares)</small>
+ fa-list-check <small>(fa-tasks)</small>
+ fa-list-ol <small>(fa-list-1-2, fa-list-numeric)</small>
+ fa-list-ul <small>(fa-list-dots)</small>
+ fa-litecoin-sign
+ fa-location-arrow
+ fa-location-crosshairs <small>(fa-location)</small>
+ fa-location-dot <small>(fa-map-marker-alt)</small>
+ fa-location-pin <small>(fa-map-marker)</small>
+ fa-location-pin-lock
+ fa-lock
+ fa-lock-open
+ fa-locust
+ fa-lungs
+ fa-lungs-virus
+ fa-lyft
+M fa-m
+ fa-magento
+ fa-magnet
+ fa-magnifying-glass <small>(fa-search)</small>
+ fa-magnifying-glass-arrow-right
+ fa-magnifying-glass-chart
+ fa-magnifying-glass-dollar <small>(fa-search-dollar)</small>
+ fa-magnifying-glass-location <small>(fa-search-location)</small>
+ fa-magnifying-glass-minus <small>(fa-search-minus)</small>
+ fa-magnifying-glass-plus <small>(fa-search-plus)</small>
+ fa-mailchimp
+ fa-manat-sign
+ fa-mandalorian
+ fa-map
+ fa-map-location <small>(fa-map-marked)</small>
+ fa-map-location-dot <small>(fa-map-marked-alt)</small>
+ fa-map-pin
+ fa-markdown
+ fa-marker
+ fa-mars
+ fa-mars-and-venus
+ fa-mars-and-venus-burst
+ fa-mars-double
+ fa-mars-stroke
+ fa-mars-stroke-right <small>(fa-mars-stroke-h)</small>
+ fa-mars-stroke-up <small>(fa-mars-stroke-v)</small>
+ fa-martini-glass <small>(fa-glass-martini-alt)</small>
+ fa-martini-glass-citrus <small>(fa-cocktail)</small>
+ fa-martini-glass-empty <small>(fa-glass-martini)</small>
+ fa-mask
+ fa-mask-face
+ fa-mask-ventilator
+ fa-masks-theater <small>(fa-theater-masks)</small>
+ fa-mastodon
+ fa-mattress-pillow
+ fa-maxcdn
+ fa-maximize <small>(fa-expand-arrows-alt)</small>
+ fa-mdb
+ fa-medal
+ fa-medapps
+ fa-medium <small>(fa-medium-m)</small>
+ fa-medrt
+ fa-meetup
+ fa-megaport
+ fa-memory
+ fa-mendeley
+ fa-menorah
+ fa-mercury
+ fa-message <small>(fa-comment-alt)</small>
+ fa-meteor
+ fa-microblog
+ fa-microchip
+ fa-microphone
+ fa-microphone-lines <small>(fa-microphone-alt)</small>
+ fa-microphone-lines-slash <small>(fa-microphone-alt-slash)</small>
+ fa-microphone-slash
+ fa-microscope
+ fa-microsoft
+ fa-mill-sign
+ fa-minimize <small>(fa-compress-arrows-alt)</small>
+ fa-minus <small>(fa-subtract)</small>
+ fa-mitten
+ fa-mix
+ fa-mixcloud
+ fa-mixer
+ fa-mizuni
+ fa-mobile <small>(fa-mobile-android, fa-mobile-phone)</small>
+ fa-mobile-button
+ fa-mobile-retro
+ fa-mobile-screen <small>(fa-mobile-android-alt)</small>
+ fa-mobile-screen-button <small>(fa-mobile-alt)</small>
+ fa-modx
+ fa-monero
+ fa-money-bill
+ fa-money-bill-1 <small>(fa-money-bill-alt)</small>
+ fa-money-bill-1-wave <small>(fa-money-bill-wave-alt)</small>
+ fa-money-bill-transfer
+ fa-money-bill-trend-up
+ fa-money-bill-wave
+ fa-money-bill-wheat
+ fa-money-bills
+ fa-money-check
+ fa-money-check-dollar <small>(fa-money-check-alt)</small>
+ fa-monument
+ fa-moon
+ fa-mortar-pestle
+ fa-mosque
+ fa-mosquito
+ fa-mosquito-net
+ fa-motorcycle
+ fa-mound
+ fa-mountain
+ fa-mountain-city
+ fa-mountain-sun
+ fa-mug-hot
+ fa-mug-saucer <small>(fa-coffee)</small>
+ fa-music
+N fa-n
+ fa-naira-sign
+ fa-napster
+ fa-neos
+ fa-network-wired
+ fa-neuter
+ fa-newspaper
+ fa-nfc-directional
+ fa-nfc-symbol
+ fa-nimblr
+ fa-node
+ fa-node-js
+ fa-not-equal
+ fa-note-sticky <small>(fa-sticky-note)</small>
+ fa-notes-medical
+ fa-npm
+ fa-ns8
+ fa-nutritionix
+O fa-o
+ fa-object-group
+ fa-object-ungroup
+ fa-octopus-deploy
+ fa-odnoklassniki
+ fa-odnoklassniki-square
+ fa-oil-can
+ fa-oil-well
+ fa-old-republic
+ fa-om
+ fa-opencart
+ fa-openid
+ fa-opera
+ fa-optin-monster
+ fa-orcid
+ fa-osi
+ fa-otter
+ fa-outdent <small>(fa-dedent)</small>
+P fa-p
+ fa-padlet
+ fa-page4
+ fa-pagelines
+ fa-pager
+ fa-paint-roller
+ fa-paintbrush <small>(fa-paint-brush)</small>
+ fa-palette
+ fa-palfed
+ fa-pallet
+ fa-panorama
+ fa-paper-plane
+ fa-paperclip
+ fa-parachute-box
+ fa-paragraph
+ fa-passport
+ fa-paste <small>(fa-file-clipboard)</small>
+ fa-patreon
+ fa-pause
+ fa-paw
+ fa-paypal
+ fa-peace
+ fa-pen
+ fa-pen-clip <small>(fa-pen-alt)</small>
+ fa-pen-fancy
+ fa-pen-nib
+ fa-pen-ruler <small>(fa-pencil-ruler)</small>
+ fa-pen-to-square <small>(fa-edit)</small>
+ fa-pencil <small>(fa-pencil-alt)</small>
+ fa-people-arrows-left-right <small>(fa-people-arrows)</small>
+ fa-people-carry-box <small>(fa-people-carry)</small>
+ fa-people-group
+ fa-people-line
+ fa-people-pulling
+ fa-people-robbery
+ fa-people-roof
+ fa-pepper-hot
+ fa-perbyte
+% fa-percent <small>(fa-percentage)</small>
+ fa-periscope
+ fa-person <small>(fa-male)</small>
+ fa-person-arrow-down-to-line
+ fa-person-arrow-up-from-line
+ fa-person-biking <small>(fa-biking)</small>
+ fa-person-booth
+ fa-person-breastfeeding
+ fa-person-burst
+ fa-person-cane
+ fa-person-chalkboard
+ fa-person-circle-check
+ fa-person-circle-exclamation
+ fa-person-circle-minus
+ fa-person-circle-plus
+ fa-person-circle-question
+ fa-person-circle-xmark
+ fa-person-digging <small>(fa-digging)</small>
+ fa-person-dots-from-line <small>(fa-diagnoses)</small>
+ fa-person-dress <small>(fa-female)</small>
+ fa-person-dress-burst
+ fa-person-drowning
+ fa-person-falling
+ fa-person-falling-burst
+ fa-person-half-dress
+ fa-person-harassing
+ fa-person-hiking <small>(fa-hiking)</small>
+ fa-person-military-pointing
+ fa-person-military-rifle
+ fa-person-military-to-person
+ fa-person-praying <small>(fa-pray)</small>
+ fa-person-pregnant
+ fa-person-rays
+ fa-person-rifle
+ fa-person-running <small>(fa-running)</small>
+ fa-person-shelter
+ fa-person-skating <small>(fa-skating)</small>
+ fa-person-skiing <small>(fa-skiing)</small>
+ fa-person-skiing-nordic <small>(fa-skiing-nordic)</small>
+ fa-person-snowboarding <small>(fa-snowboarding)</small>
+ fa-person-swimming <small>(fa-swimmer)</small>
+ fa-person-through-window
+ fa-person-walking <small>(fa-walking)</small>
+ fa-person-walking-arrow-loop-left
+ fa-person-walking-arrow-right
+ fa-person-walking-dashed-line-arrow-right
+ fa-person-walking-luggage
+ fa-person-walking-with-cane <small>(fa-blind)</small>
+ fa-peseta-sign
+ fa-peso-sign
+ fa-phabricator
+ fa-phoenix-framework
+ fa-phoenix-squadron
+ fa-phone
+ fa-phone-flip <small>(fa-phone-alt)</small>
+ fa-phone-slash
+ fa-phone-volume <small>(fa-volume-control-phone)</small>
+ fa-photo-film <small>(fa-photo-video)</small>
+ fa-php
+ fa-pied-piper
+ fa-pied-piper-alt
+ fa-pied-piper-hat
+ fa-pied-piper-pp
+ fa-pied-piper-square
+ fa-piggy-bank
+ fa-pills
+ fa-pinterest
+ fa-pinterest-p
+ fa-pinterest-square
+ fa-pix
+ fa-pizza-slice
+ fa-place-of-worship
+ fa-plane
+ fa-plane-arrival
+ fa-plane-circle-check
+ fa-plane-circle-exclamation
+ fa-plane-circle-xmark
+ fa-plane-departure
+ fa-plane-lock
+ fa-plane-slash
+ fa-plane-up
+ fa-plant-wilt
+ fa-plate-wheat
+ fa-play
+ fa-playstation
+ fa-plug
+ fa-plug-circle-bolt
+ fa-plug-circle-check
+ fa-plug-circle-exclamation
+ fa-plug-circle-minus
+ fa-plug-circle-plus
+ fa-plug-circle-xmark
++ fa-plus <small>(fa-add)</small>
+ fa-plus-minus
+ fa-podcast
+ fa-poo
+ fa-poo-storm <small>(fa-poo-bolt)</small>
+ fa-poop
+ fa-power-off
+ fa-prescription
+ fa-prescription-bottle
+ fa-prescription-bottle-medical <small>(fa-prescription-bottle-alt)</small>
+ fa-print
+ fa-product-hunt
+ fa-pump-medical
+ fa-pump-soap
+ fa-pushed
+ fa-puzzle-piece
+ fa-python
+Q fa-q
+ fa-qq
+ fa-qrcode
+? fa-question
+ fa-quinscape
+ fa-quora
+ fa-quote-left <small>(fa-quote-left-alt)</small>
+ fa-quote-right <small>(fa-quote-right-alt)</small>
+R fa-r
+ fa-r-project
+ fa-radiation
+ fa-radio
+ fa-rainbow
+ fa-ranking-star
+ fa-raspberry-pi
+ fa-ravelry
+ fa-react
+ fa-reacteurope
+ fa-readme
+ fa-rebel
+ fa-receipt
+ fa-record-vinyl
+ fa-rectangle-ad <small>(fa-ad)</small>
+ fa-rectangle-list <small>(fa-list-alt)</small>
+ fa-rectangle-xmark <small>(fa-rectangle-times, fa-times-rectangle, fa-window-close)</small>
+ fa-recycle
+ fa-red-river
+ fa-reddit
+ fa-reddit-alien
+ fa-reddit-square
+ fa-redhat
+ fa-registered
+ fa-renren
+ fa-repeat
+ fa-reply <small>(fa-mail-reply)</small>
+ fa-reply-all <small>(fa-mail-reply-all)</small>
+ fa-replyd
+ fa-republican
+ fa-researchgate
+ fa-resolving
+ fa-restroom
+ fa-retweet
+ fa-rev
+ fa-ribbon
+ fa-right-from-bracket <small>(fa-sign-out-alt)</small>
+ fa-right-left <small>(fa-exchange-alt)</small>
+ fa-right-long <small>(fa-long-arrow-alt-right)</small>
+ fa-right-to-bracket <small>(fa-sign-in-alt)</small>
+ fa-ring
+ fa-road
+ fa-road-barrier
+ fa-road-bridge
+ fa-road-circle-check
+ fa-road-circle-exclamation
+ fa-road-circle-xmark
+ fa-road-lock
+ fa-road-spikes
+ fa-robot
+ fa-rocket
+ fa-rocketchat
+ fa-rockrms
+ fa-rotate <small>(fa-sync-alt)</small>
+ fa-rotate-left <small>(fa-rotate-back, fa-rotate-backward, fa-undo-alt)</small>
+ fa-rotate-right <small>(fa-redo-alt, fa-rotate-forward)</small>
+ fa-route
+ fa-rss <small>(fa-feed)</small>
+ fa-ruble-sign <small>(fa-rouble, fa-rub, fa-ruble)</small>
+ fa-rug
+ fa-ruler
+ fa-ruler-combined
+ fa-ruler-horizontal
+ fa-ruler-vertical
+ fa-rupee-sign <small>(fa-rupee)</small>
+ fa-rupiah-sign
+ fa-rust
+S fa-s
+ fa-sack-dollar
+ fa-sack-xmark
+ fa-safari
+ fa-sailboat
+ fa-salesforce
+ fa-sass
+ fa-satellite
+ fa-satellite-dish
+ fa-scale-balanced <small>(fa-balance-scale)</small>
+ fa-scale-unbalanced <small>(fa-balance-scale-left)</small>
+ fa-scale-unbalanced-flip <small>(fa-balance-scale-right)</small>
+ fa-schlix
+ fa-school
+ fa-school-circle-check
+ fa-school-circle-exclamation
+ fa-school-circle-xmark
+ fa-school-flag
+ fa-school-lock
+ fa-scissors <small>(fa-cut)</small>
+ fa-screenpal
+ fa-screwdriver
+ fa-screwdriver-wrench <small>(fa-tools)</small>
+ fa-scribd
+ fa-scroll
+ fa-scroll-torah <small>(fa-torah)</small>
+ fa-sd-card
+ fa-searchengin
+ fa-section
+ fa-seedling <small>(fa-sprout)</small>
+ fa-sellcast
+ fa-sellsy
+ fa-server
+ fa-servicestack
+ fa-shapes <small>(fa-triangle-circle-square)</small>
+ fa-share <small>(fa-arrow-turn-right, fa-mail-forward)</small>
+ fa-share-from-square <small>(fa-share-square)</small>
+ fa-share-nodes <small>(fa-share-alt)</small>
+ fa-sheet-plastic
+ fa-shekel-sign <small>(fa-ils, fa-shekel, fa-sheqel, fa-sheqel-sign)</small>
+ fa-shield <small>(fa-shield-blank)</small>
+ fa-shield-cat
+ fa-shield-dog
+ fa-shield-halved <small>(fa-shield-alt)</small>
+ fa-shield-heart
+ fa-shield-virus
+ fa-ship
+ fa-shirt <small>(fa-t-shirt, fa-tshirt)</small>
+ fa-shirtsinbulk
+ fa-shoe-prints
+ fa-shop <small>(fa-store-alt)</small>
+ fa-shop-lock
+ fa-shop-slash <small>(fa-store-alt-slash)</small>
+ fa-shopify
+ fa-shopware
+ fa-shower
+ fa-shrimp
+ fa-shuffle <small>(fa-random)</small>
+ fa-shuttle-space <small>(fa-space-shuttle)</small>
+ fa-sign-hanging <small>(fa-sign)</small>
+ fa-signal <small>(fa-signal-5, fa-signal-perfect)</small>
+ fa-signature
+ fa-signs-post <small>(fa-map-signs)</small>
+ fa-sim-card
+ fa-simplybuilt
+ fa-sink
+ fa-sistrix
+ fa-sitemap
+ fa-sith
+ fa-sitrox
+ fa-sketch
+ fa-skull
+ fa-skull-crossbones
+ fa-skyatlas
+ fa-skype
+ fa-slack <small>(fa-slack-hash)</small>
+ fa-slash
+ fa-sleigh
+ fa-sliders <small>(fa-sliders-h)</small>
+ fa-slideshare
+ fa-smog
+ fa-smoking
+ fa-snapchat <small>(fa-snapchat-ghost)</small>
+ fa-snapchat-square
+ fa-snowflake
+ fa-snowman
+ fa-snowplow
+ fa-soap
+ fa-socks
+ fa-solar-panel
+ fa-sort <small>(fa-unsorted)</small>
+ fa-sort-down <small>(fa-sort-desc)</small>
+ fa-sort-up <small>(fa-sort-asc)</small>
+ fa-soundcloud
+ fa-sourcetree
+ fa-spa
+ fa-spaghetti-monster-flying <small>(fa-pastafarianism)</small>
+ fa-speakap
+ fa-speaker-deck
+ fa-spell-check
+ fa-spider
+ fa-spinner
+ fa-splotch
+ fa-spoon <small>(fa-utensil-spoon)</small>
+ fa-spotify
+ fa-spray-can
+ fa-spray-can-sparkles <small>(fa-air-freshener)</small>
+ fa-square
+ fa-square-arrow-up-right <small>(fa-external-link-square)</small>
+ fa-square-caret-down <small>(fa-caret-square-down)</small>
+ fa-square-caret-left <small>(fa-caret-square-left)</small>
+ fa-square-caret-right <small>(fa-caret-square-right)</small>
+ fa-square-caret-up <small>(fa-caret-square-up)</small>
+ fa-square-check <small>(fa-check-square)</small>
+ fa-square-envelope <small>(fa-envelope-square)</small>
+ fa-square-font-awesome
+ fa-square-font-awesome-stroke <small>(fa-font-awesome-alt)</small>
+ fa-square-full
+ fa-square-h <small>(fa-h-square)</small>
+ fa-square-minus <small>(fa-minus-square)</small>
+ fa-square-nfi
+ fa-square-parking <small>(fa-parking)</small>
+ fa-square-pen <small>(fa-pen-square, fa-pencil-square)</small>
+ fa-square-person-confined
+ fa-square-phone <small>(fa-phone-square)</small>
+ fa-square-phone-flip <small>(fa-phone-square-alt)</small>
+ fa-square-plus <small>(fa-plus-square)</small>
+ fa-square-poll-horizontal <small>(fa-poll-h)</small>
+ fa-square-poll-vertical <small>(fa-poll)</small>
+ fa-square-root-variable <small>(fa-square-root-alt)</small>
+ fa-square-rss <small>(fa-rss-square)</small>
+ fa-square-share-nodes <small>(fa-share-alt-square)</small>
+ fa-square-up-right <small>(fa-external-link-square-alt)</small>
+ fa-square-virus
+ fa-square-xmark <small>(fa-times-square, fa-xmark-square)</small>
+ fa-squarespace
+ fa-stack-exchange
+ fa-stack-overflow
+ fa-stackpath
+ fa-staff-aesculapius <small>(fa-rod-asclepius, fa-rod-snake, fa-staff-snake)</small>
+ fa-stairs
+ fa-stamp
+ fa-star
+ fa-star-and-crescent
+ fa-star-half
+ fa-star-half-stroke <small>(fa-star-half-alt)</small>
+ fa-star-of-david
+ fa-star-of-life
+ fa-staylinked
+ fa-steam
+ fa-steam-square
+ fa-steam-symbol
+ fa-sterling-sign <small>(fa-gbp, fa-pound-sign)</small>
+ fa-stethoscope
+ fa-sticker-mule
+ fa-stop
+ fa-stopwatch
+ fa-stopwatch-20
+ fa-store
+ fa-store-slash
+ fa-strava
+ fa-street-view
+ fa-strikethrough
+ fa-stripe
+ fa-stripe-s
+ fa-stroopwafel
+ fa-studiovinari
+ fa-stumbleupon
+ fa-stumbleupon-circle
+ fa-subscript
+ fa-suitcase
+ fa-suitcase-medical <small>(fa-medkit)</small>
+ fa-suitcase-rolling
+ fa-sun
+ fa-sun-plant-wilt
+ fa-superpowers
+ fa-superscript
+ fa-supple
+ fa-suse
+ fa-swatchbook
+ fa-swift
+ fa-symfony
+ fa-synagogue
+ fa-syringe
+T fa-t
+ fa-table
+ fa-table-cells <small>(fa-th)</small>
+ fa-table-cells-large <small>(fa-th-large)</small>
+ fa-table-columns <small>(fa-columns)</small>
+ fa-table-list <small>(fa-th-list)</small>
+ fa-table-tennis-paddle-ball <small>(fa-ping-pong-paddle-ball, fa-table-tennis)</small>
+ fa-tablet <small>(fa-tablet-android)</small>
+ fa-tablet-button
+ fa-tablet-screen-button <small>(fa-tablet-alt)</small>
+ fa-tablets
+ fa-tachograph-digital <small>(fa-digital-tachograph)</small>
+ fa-tag
+ fa-tags
+ fa-tape
+ fa-tarp
+ fa-tarp-droplet
+ fa-taxi <small>(fa-cab)</small>
+ fa-teamspeak
+ fa-teeth
+ fa-teeth-open
+ fa-telegram <small>(fa-telegram-plane)</small>
+ fa-temperature-arrow-down <small>(fa-temperature-down)</small>
+ fa-temperature-arrow-up <small>(fa-temperature-up)</small>
+ fa-temperature-empty <small>(fa-temperature-0, fa-thermometer-0, fa-thermometer-empty)</small>
+ fa-temperature-full <small>(fa-temperature-4, fa-thermometer-4, fa-thermometer-full)</small>
+ fa-temperature-half <small>(fa-temperature-2, fa-thermometer-2, fa-thermometer-half)</small>
+ fa-temperature-high
+ fa-temperature-low
+ fa-temperature-quarter <small>(fa-temperature-1, fa-thermometer-1, fa-thermometer-quarter)</small>
+ fa-temperature-three-quarters <small>(fa-temperature-3, fa-thermometer-3, fa-thermometer-three-quarters)</small>
+ fa-tencent-weibo
+ fa-tenge-sign <small>(fa-tenge)</small>
+ fa-tent
+ fa-tent-arrow-down-to-line
+ fa-tent-arrow-left-right
+ fa-tent-arrow-turn-left
+ fa-tent-arrows-down
+ fa-tents
+ fa-terminal
+ fa-text-height
+ fa-text-slash <small>(fa-remove-format)</small>
+ fa-text-width
+ fa-the-red-yeti
+ fa-themeco
+ fa-themeisle
+ fa-thermometer
+ fa-think-peaks
+ fa-thumbs-down
+ fa-thumbs-up
+ fa-thumbtack <small>(fa-thumb-tack)</small>
+ fa-ticket
+ fa-ticket-simple <small>(fa-ticket-alt)</small>
+ fa-tiktok
+ fa-timeline
+ fa-toggle-off
+ fa-toggle-on
+ fa-toilet
+ fa-toilet-paper
+ fa-toilet-paper-slash
+ fa-toilet-portable
+ fa-toilets-portable
+ fa-toolbox
+ fa-tooth
+ fa-torii-gate
+ fa-tornado
+ fa-tower-broadcast <small>(fa-broadcast-tower)</small>
+ fa-tower-cell
+ fa-tower-observation
+ fa-tractor
+ fa-trade-federation
+ fa-trademark
+ fa-traffic-light
+ fa-trailer
+ fa-train
+ fa-train-subway <small>(fa-subway)</small>
+ fa-train-tram <small>(fa-tram)</small>
+ fa-transgender <small>(fa-transgender-alt)</small>
+ fa-trash
+ fa-trash-arrow-up <small>(fa-trash-restore)</small>
+ fa-trash-can <small>(fa-trash-alt)</small>
+ fa-trash-can-arrow-up <small>(fa-trash-restore-alt)</small>
+ fa-tree
+ fa-tree-city
+ fa-trello
+ fa-triangle-exclamation <small>(fa-exclamation-triangle, fa-warning)</small>
+ fa-trophy
+ fa-trowel
+ fa-trowel-bricks
+ fa-truck
+ fa-truck-arrow-right
+ fa-truck-droplet
+ fa-truck-fast <small>(fa-shipping-fast)</small>
+ fa-truck-field
+ fa-truck-field-un
+ fa-truck-front
+ fa-truck-medical <small>(fa-ambulance)</small>
+ fa-truck-monster
+ fa-truck-moving
+ fa-truck-pickup
+ fa-truck-plane
+ fa-truck-ramp-box <small>(fa-truck-loading)</small>
+ fa-tty <small>(fa-teletype)</small>
+ fa-tumblr
+ fa-tumblr-square
+ fa-turkish-lira-sign <small>(fa-try, fa-turkish-lira)</small>
+ fa-turn-down <small>(fa-level-down-alt)</small>
+ fa-turn-up <small>(fa-level-up-alt)</small>
+ fa-tv <small>(fa-television, fa-tv-alt)</small>
+ fa-twitch
+ fa-twitter
+ fa-twitter-square
+ fa-typo3
+U fa-u
+ fa-uber
+ fa-ubuntu
+ fa-uikit
+ fa-umbraco
+ fa-umbrella
+ fa-umbrella-beach
+ fa-uncharted
+ fa-underline
+ fa-uniregistry
+ fa-unity
+ fa-universal-access
+ fa-unlock
+ fa-unlock-keyhole <small>(fa-unlock-alt)</small>
+ fa-unsplash
+ fa-untappd
+ fa-up-down <small>(fa-arrows-alt-v)</small>
+ fa-up-down-left-right <small>(fa-arrows-alt)</small>
+ fa-up-long <small>(fa-long-arrow-alt-up)</small>
+ fa-up-right-and-down-left-from-center <small>(fa-expand-alt)</small>
+ fa-up-right-from-square <small>(fa-external-link-alt)</small>
+ fa-upload
+ fa-ups
+ fa-usb
+ fa-user
+ fa-user-astronaut
+ fa-user-check
+ fa-user-clock
+ fa-user-doctor <small>(fa-user-md)</small>
+ fa-user-gear <small>(fa-user-cog)</small>
+ fa-user-graduate
+ fa-user-group <small>(fa-user-friends)</small>
+ fa-user-injured
+ fa-user-large <small>(fa-user-alt)</small>
+ fa-user-large-slash <small>(fa-user-alt-slash)</small>
+ fa-user-lock
+ fa-user-minus
+ fa-user-ninja
+ fa-user-nurse
+ fa-user-pen <small>(fa-user-edit)</small>
+ fa-user-plus
+ fa-user-secret
+ fa-user-shield
+ fa-user-slash
+ fa-user-tag
+ fa-user-tie
+ fa-user-xmark <small>(fa-user-times)</small>
+ fa-users
+ fa-users-between-lines
+ fa-users-gear <small>(fa-users-cog)</small>
+ fa-users-line
+ fa-users-rays
+ fa-users-rectangle
+ fa-users-slash
+ fa-users-viewfinder
+ fa-usps
+ fa-ussunnah
+ fa-utensils <small>(fa-cutlery)</small>
+V fa-v
+ fa-vaadin
+ fa-van-shuttle <small>(fa-shuttle-van)</small>
+ fa-vault
+ fa-vector-square
+ fa-venus
+ fa-venus-double
+ fa-venus-mars
+ fa-vest
+ fa-vest-patches
+ fa-viacoin
+ fa-viadeo
+ fa-viadeo-square
+ fa-vial
+ fa-vial-circle-check
+ fa-vial-virus
+ fa-vials
+ fa-viber
+ fa-video <small>(fa-video-camera)</small>
+ fa-video-slash
+ fa-vihara
+ fa-vimeo
+ fa-vimeo-square
+ fa-vimeo-v
+ fa-vine
+ fa-virus
+ fa-virus-covid
+ fa-virus-covid-slash
+ fa-virus-slash
+ fa-viruses
+ fa-vk
+ fa-vnv
+ fa-voicemail
+ fa-volcano
+ fa-volleyball <small>(fa-volleyball-ball)</small>
+ fa-volume-high <small>(fa-volume-up)</small>
+ fa-volume-low <small>(fa-volume-down)</small>
+ fa-volume-off
+ fa-volume-xmark <small>(fa-volume-mute, fa-volume-times)</small>
+ fa-vr-cardboard
+ fa-vuejs
+W fa-w
+ fa-walkie-talkie
+ fa-wallet
+ fa-wand-magic <small>(fa-magic)</small>
+ fa-wand-magic-sparkles <small>(fa-magic-wand-sparkles)</small>
+ fa-wand-sparkles
+ fa-warehouse
+ fa-watchman-monitoring
+ fa-water
+ fa-water-ladder <small>(fa-ladder-water, fa-swimming-pool)</small>
+ fa-wave-square
+ fa-waze
+ fa-weebly
+ fa-weibo
+ fa-weight-hanging
+ fa-weight-scale <small>(fa-weight)</small>
+ fa-weixin
+ fa-whatsapp
+ fa-whatsapp-square
+ fa-wheat-awn <small>(fa-wheat-alt)</small>
+ fa-wheat-awn-circle-exclamation
+ fa-wheelchair
+ fa-wheelchair-move <small>(fa-wheelchair-alt)</small>
+ fa-whiskey-glass <small>(fa-glass-whiskey)</small>
+ fa-whmcs
+ fa-wifi <small>(fa-wifi-3, fa-wifi-strong)</small>
+ fa-wikipedia-w
+ fa-wind
+ fa-window-maximize
+ fa-window-minimize
+ fa-window-restore
+ fa-windows
+ fa-wine-bottle
+ fa-wine-glass
+ fa-wine-glass-empty <small>(fa-wine-glass-alt)</small>
+ fa-wirsindhandwerk <small>(fa-wsh)</small>
+ fa-wix
+ fa-wizards-of-the-coast
+ fa-wodu
+ fa-wolf-pack-battalion
+ fa-won-sign <small>(fa-krw, fa-won)</small>
+ fa-wordpress
+ fa-wordpress-simple
+ fa-worm
+ fa-wpbeginner
+ fa-wpexplorer
+ fa-wpforms
+ fa-wpressr
+ fa-wrench
+X fa-x
+ fa-x-ray
+ fa-xbox
+ fa-xing
+ fa-xing-square
+ fa-xmark <small>(fa-close, fa-multiply, fa-remove, fa-times)</small>
+ fa-xmarks-lines
+Y fa-y
+ fa-y-combinator
+ fa-yahoo
+ fa-yammer
+ fa-yandex
+ fa-yandex-international
+ fa-yarn
+ fa-yelp
+ fa-yen-sign <small>(fa-cny, fa-jpy, fa-rmb, fa-yen)</small>
+ fa-yin-yang
+ fa-yoast
+ fa-youtube
+ fa-youtube-square
+Z fa-z
+ fa-zhihu


### PR DESCRIPTION
Based off of `nerdextractor.py`.

Open Questions:
* Should we fetch from something like [jsDelivr](https://www.jsdelivr.com/?docs=gh) instead of raw.githubusercontent.com? GitHub has rate limits/
* Do we want `fontawesome6extractor.py` to be versioned to Font Awesome 6 or generic?
* Naming: could shorten to `fa6extractor.py`