### PR TITLE
add option --single to only select one emoji

### DIFF
--- a/src/picker/docs/rofimoji.1
+++ b/src/picker/docs/rofimoji.1
@@ -30,7 +30,7 @@ brown\f[R],\f[I]black\f[R],\f[I]ask\f[R]}] [\f[B]--files\f[R]
 {\f[I]all\f[R],\f[I]FILE\f[R] [\f[I]FILE\f[R] \&...]]}
 [\f[B]--prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]--selector-args\f[R]
 \f[I]SELECTOR_ARGS\f[R]] [\f[B]--max-recent\f[R] \f[I]MAX_RECENT\f[R]]
-[\f[B]--no-frecency\f[R]] [\f[B]--clipboarder\f[R]
+[\f[B]--no-frecency\f[R]] [\f[B]--single\f[R]] [\f[B]--clipboarder\f[R]
 \f[I]CLIPBOARDER\f[R]] [\f[B]--typer\f[R] \f[I]TYPER\f[R]]
 [\f[B]--selector\f[R] \f[I]SELECTOR\f[R]]
 .SH DESCRIPTION
@@ -82,6 +82,9 @@ than 10)
 .TP
 --no-frecency
 Don\[cq]t show frequently used characters at the start.
+.TP
+--single
+Disable multiple emoji selection.
 .TP
 --clipboarder \f[I]CLIPBOARDER\f[R]
 Possible values: xsel, xclip, wl-copy

--- a/src/picker/docs/rofimoji.1.md
+++ b/src/picker/docs/rofimoji.1.md
@@ -12,7 +12,7 @@
 | **rofimoji** \[**-h**] \[**\--version**] \[**\--action** {*type*,*copy*,*clipboard*,*unicode*,*copy-unicode*,*print*}]
          \[**\--skin-tone** {*neutral*,*light*,*medium-light*,*moderate*,*dark brown*,*black*,*ask*}]
          \[**\--files** {*all*,*FILE* \[*FILE* ...]]} \[**\--prompt** *PROMPT*]
-         \[**\--selector-args** *SELECTOR_ARGS*] \[**\--max-recent** *MAX_RECENT*] \[**\--no-frecency**]
+         \[**\--selector-args** *SELECTOR_ARGS*] \[**\--max-recent** *MAX_RECENT*] \[**\--no-frecency**] \[**\--single**]
          \[**\--clipboarder** *CLIPBOARDER*] \[**\--typer** *TYPER*] \[**\--selector** *SELECTOR*]
 
 # DESCRIPTION
@@ -63,6 +63,10 @@ Select, insert, or copy Unicode characters like emoji using rofi.
 \--no-frecency
 
 :  Don't show frequently used characters at the start.
+
+\--single
+
+:  Disable multiple emoji selection.
 
 \--clipboarder _CLIPBOARDER_
 

--- a/src/picker/rofimoji.py
+++ b/src/picker/rofimoji.py
@@ -122,6 +122,13 @@ class Rofimoji:
         )
         parser.set_defaults(frecency=True)
         parser.add_argument(
+            '--single',
+            dest='multi_select',
+            action='store_false',
+            help='Disable multiple emoji selection'
+        )
+        parser.set_defaults(multi_select=True)
+        parser.add_argument(
             '--selector',
             dest='selector',
             action='store',
@@ -351,7 +358,8 @@ class Rofimoji:
             self.format_recent_characters(),
             self.args.prompt,
             self.args.keybindings,
-            self.args.selector_args
+            self.args.selector_args,
+            self.args.multi_select
         )
 
     def process_chosen_characters(self, chosen_characters: List[str]) -> str:

--- a/src/picker/selector.py
+++ b/src/picker/selector.py
@@ -30,7 +30,8 @@ class Selector:
             recent_characters: str,
             prompt: str,
             keybindings: Dict[Action, str],
-            additional_args: List[str]
+            additional_args: List[str],
+            multi_select: bool
     ) -> Tuple[Union[Action, DEFAULT, CANCEL], Union[str, Shortcut]]:
         print('Could not find a valid way to show the selection. Please check the required dependencies.')
         exit(4)
@@ -55,14 +56,15 @@ class Rofi(Selector):
             recent_characters: str,
             prompt: str,
             keybindings: Dict[Action, str],
-            additional_args: List[str]
+            additional_args: List[str],
+            multi_select: bool
     ) -> Tuple[Union[Action, DEFAULT, CANCEL], Union[str, Shortcut]]:
         parameters = [
             'rofi',
             '-dmenu',
             '-markup-rows',
             '-i',
-            '-multi-select',
+            '-multi-select' if multi_select else '',
             '-p',
             prompt,
             '-kb-custom-11',
@@ -139,7 +141,8 @@ class Wofi(Selector):
             recent_characters: str,
             prompt: str,
             keybindings: Dict[Action, str],
-            additional_args: List[str]
+            additional_args: List[str],
+            multi_select: bool
     ) -> Tuple[Union[Action, DEFAULT, CANCEL], Union[str, Shortcut]]:
         parameters = [
             'wofi',


### PR DESCRIPTION
this options calls rofi without -multi-select enabled, thus removing the checkboxs

"fixes" #127, only need to run it as `rofimoji --single`

<details>
    <summary>Preview</summary>
    Without --single
    <img src="https://user-images.githubusercontent.com/93066036/188666985-ba2fd2df-bc25-4841-b6b8-90969534cf69.jpg">
    With --single
    <img src="https://user-images.githubusercontent.com/93066036/188667031-020fe8a2-1c95-4c1b-b358-f1bd17a6767d.jpg">
</details>