### PR TITLE
Only show recents from the current set of characters

### DIFF
--- a/src/picker/mode.py
+++ b/src/picker/mode.py
@@ -119,19 +119,16 @@ class ModeRofimoji:
         self.clipboarder = Clipboarder.best_option(self.args.clipboarder)
 
     def show_characters(self, state: State) -> None:
-        recent_characters = self.__format_recent_characters(load_recent_characters(self.args.max_recent))
+        all_characters = read_characters_from_files(
+                    self.args.files, load_frecent_characters() if self.args.frecency else [], self.args.use_additional
+                )
+        recent_characters = self.__format_recent_characters(load_recent_characters(self.args.max_recent, all_characters))
 
         state.output = "\x00markup-rows\x1ftrue\n"
         state.output += "\x00use-hot-keys\x1ftrue\n"
         if len(recent_characters) > 0:
             state.output += f"\x00message\x1f{recent_characters}"
-        state.output += "\n".join(
-            self.__format_characters(
-                read_characters_from_files(
-                    self.args.files, load_frecent_characters() if self.args.frecency else [], self.args.use_additional
-                )
-            )
-        )
+        state.output += "\n".join(self.__format_characters(all_characters))
         state.output += "\n"
 
         state.step += 1
@@ -149,7 +146,10 @@ class ModeRofimoji:
 
     def handle_shortcuts(self, state: State) -> None:
         if 10 <= state.return_code <= 19:
-            state.processed_characters = load_recent_characters(self.args.max_recent)[state.return_code - 10]
+            all_characters = read_characters_from_files(
+                self.args.files, load_frecent_characters() if self.args.frecency else [], self.args.use_additional
+            )
+            state.processed_characters = load_recent_characters(self.args.max_recent, all_characters)[state.return_code - 10]
             state.reset_current_input()
             state.step += 2
             return
@@ -213,7 +213,10 @@ class ModeRofimoji:
         state.step += 1
 
     def execute_actions(self, state: State) -> Optional[str]:
-        save_recent_characters(state.processed_characters, self.args.max_recent)
+        all_characters = read_characters_from_files(
+            self.args.files, load_frecent_characters() if self.args.frecency else [], self.args.use_additional
+        )
+        save_recent_characters(state.processed_characters, all_characters)
         execute_action(state.processed_characters, state.actions)
         state.step += 1
         return

--- a/src/picker/paths.py
+++ b/src/picker/paths.py
@@ -7,7 +7,7 @@ data_home = Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")).expanduser()
 cache_home = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
 
 config_file_locations = [str(directory / "rofimoji.rc") for directory in [config_home] + config_global]
-recents_file_location = data_home / "rofimoji" / "recent"
+recents_files_directory = data_home / "rofimoji" / "recents"
 frecency_file_location = data_home / "rofimoji" / "frecency"
 custom_additional_files_location = data_home / "rofimoji" / "data"
 

--- a/src/picker/recent.py
+++ b/src/picker/recent.py
@@ -1,26 +1,22 @@
 from typing import List, Dict
-import hashlib
 
 from .paths import *
 
-def calculate_character_set_hash(character_set: Dict[str, str]) -> str:
-    character_string = "".join(sorted(character_set.keys()))
-    return hashlib.md5(character_string.encode()).hexdigest()
 
-def load_recent_characters(max_recent: int, character_set: Dict[str, str]) -> List[str]:
+def load_recent_characters(max_recent: int, character_set_hash: str) -> List[str]:
     recents_files_directory.mkdir(parents=True, exist_ok=True)
-    recents_file_location = recents_files_directory / calculate_character_set_hash(character_set)
+    recents_file_location = recents_files_directory / character_set_hash
     try:
         return [char.strip("\n") for char in recents_file_location.read_text().strip("\n").split("\n")][:max_recent]
     except FileNotFoundError:
         return []
 
 
-def save_recent_characters(new_characters: str, character_set: Dict[str, str]) -> None:
+def save_recent_characters(new_characters: str, character_set_hash: str) -> None:
     max_recent = 10
 
     recents_files_directory.mkdir(parents=True, exist_ok=True)
-    old_file_name = recents_files_directory / calculate_character_set_hash(character_set)
+    old_file_name = recents_files_directory / character_set_hash
     new_file_name = old_file_name.with_name("recent.tmp")
 
     new_file_name.parent.mkdir(parents=True, exist_ok=True)

--- a/src/picker/recent.py
+++ b/src/picker/recent.py
@@ -1,21 +1,26 @@
-from typing import List
+from typing import List, Dict
+import hashlib
 
 from .paths import *
 
+def calculate_character_set_hash(character_set: Dict[str, str]) -> str:
+    character_string = "".join(sorted(character_set.keys()))
+    return hashlib.md5(character_string.encode()).hexdigest()
 
-def load_recent_characters(max_recent: int) -> List[str]:
+def load_recent_characters(max_recent: int, character_set: Dict[str, str]) -> List[str]:
+    recents_files_directory.mkdir(parents=True, exist_ok=True)
+    recents_file_location = recents_files_directory / calculate_character_set_hash(character_set)
     try:
         return [char.strip("\n") for char in recents_file_location.read_text().strip("\n").split("\n")][:max_recent]
     except FileNotFoundError:
         return []
 
 
-def save_recent_characters(new_characters: str, max_recent: int) -> None:
-    if max_recent == 0:
-        return
-    max_recent = min(max_recent, 10)
+def save_recent_characters(new_characters: str, character_set: Dict[str, str]) -> None:
+    max_recent = 10
 
-    old_file_name = recents_file_location
+    recents_files_directory.mkdir(parents=True, exist_ok=True)
+    old_file_name = recents_files_directory / calculate_character_set_hash(character_set)
     new_file_name = old_file_name.with_name("recent.tmp")
 
     new_file_name.parent.mkdir(parents=True, exist_ok=True)

--- a/src/picker/standalone.py
+++ b/src/picker/standalone.py
@@ -29,23 +29,26 @@ class StandaloneRofimoji:
         elif action != DEFAULT():
             self.args.actions = [action]
 
+        all_characters = read_characters_from_files(
+            self.args.files, load_frecent_characters() if self.args.frecency else [], self.args.use_additional
+        )
         if isinstance(value, Shortcut):
-            characters = load_recent_characters(self.args.max_recent)[value.index]
+            characters = load_recent_characters(self.args.max_recent, all_characters)[value.index]
         else:
             characters = self.__process_chosen_characters(value)
 
         if Action.MENU in self.args.actions:
             self.args.actions = self.selector.show_action_menu(self.args.selector_args)
 
-        save_recent_characters(characters, self.args.max_recent)
+        save_recent_characters(characters, all_characters)
         execute_action(characters, self.args.actions, self.active_window, self.args.typer, self.args.clipboarder)
 
     def __open_main_selector_window(self) -> Tuple[Union[Action, DEFAULT, CANCEL], Union[List[str], Shortcut]]:
         return self.selector.show_character_selection(
-            read_characters_from_files(
+                all_characters := read_characters_from_files(
                 self.args.files, load_frecent_characters() if self.args.frecency else [], self.args.use_additional
             ),
-            load_recent_characters(self.args.max_recent),
+            load_recent_characters(self.args.max_recent, all_characters),
             self.args.prompt,
             self.args.show_description,
             self.args.use_icons,


### PR DESCRIPTION
Before this change, when using `rofimoji` with different sets of characters, the recent characters may include characters which aren't available in the current set.

![image](https://github.com/fdw/rofimoji/assets/43895423/afa751cb-0812-4ce2-810c-64d3432382f6)
![image](https://github.com/fdw/rofimoji/assets/43895423/b133431b-5b68-49ad-85d7-6ff8dd89c232)

After this change:

![image](https://github.com/fdw/rofimoji/assets/43895423/f75ad2dd-d225-4cce-a2b0-5910ef19ef32)
![image](https://github.com/fdw/rofimoji/assets/43895423/a451dc67-4d23-4995-981e-dc378372e73a)