### PR TITLE
Set ydotool typing delay to zero ⚡

### DIFF
--- a/src/picker/typer/ydotool.py
+++ b/src/picker/typer/ydotool.py
@@ -68,7 +68,7 @@ class YdotoolTyper(Typer):
 
             keypresses.extend([f"{_SPACE_KEY_CODE}:{_PRESS}", f"{_SPACE_KEY_CODE}:{_RELEASE}"])
 
-        run(["ydotool", "key", *keypresses])
+        run(["ydotool", "key", "--key-delay", "0", *keypresses])
 
     def insert_from_clipboard(self, active_window: str) -> None:
         run(


### PR DESCRIPTION
Adding a key delay of zero between typing the unicode for characters makes the time between selecting a character and the selected character showing up faster since the default delay between typing of character of ydotool is 12ms.
To illustrate what I mean, here is a recording of rofimoji typing 🙂 without and with the performance improvement.

https://github.com/user-attachments/assets/f59d5736-654b-406f-b31d-e54f5f3f65ca


https://github.com/user-attachments/assets/70ba1b69-9b31-4e40-855d-6e559b11b7ed

